### PR TITLE
Build arm64 based images

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -7,6 +7,10 @@ network-problem-detector:
         preprocess:
           'inject-commit-hash'
       publish:
+        oci-builder: docker-buildx
+        platforms:
+        - linux/amd64
+        - linux/arm64
         dockerimages:
           network-problem-detector:
             inputs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ FROM golang:1.18.3 AS builder
 
 WORKDIR /build
 COPY . .
-RUN make release
+ARG TARGETARCH
+RUN make release GOARCH=$TARGETARCH
 
 ############# network-problem-detector
 FROM gcr.io/distroless/static-debian11 AS network-problem-detector

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ REPO_ROOT             := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))
 VERSION               := $(shell cat VERSION)
 IMAGE_TAG             := $(VERSION)
 EFFECTIVE_VERSION     := $(VERSION)-$(shell git rev-parse HEAD)
+GOARCH                := amd64
 
 .PHONY: revendor
 revendor:
@@ -27,7 +28,7 @@ format:
 
 .PHONY: build
 build:
-	@CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o $(EXECUTABLE) \
+	@CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) GO111MODULE=on go build -o $(EXECUTABLE) \
         -mod=vendor \
 	    -ldflags "-X 'main.Version=$(EFFECTIVE_VERSION)' -X 'main.ImageTag=$(IMAGE_TAG)'"\
 	    ./cmd/nwpd
@@ -44,7 +45,7 @@ build-local:
 
 .PHONY: release
 release:
-	@CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o $(EXECUTABLE) \
+	@CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) GO111MODULE=on go build -o $(EXECUTABLE) \
         -mod=vendor \
         -ldflags "-w -X 'main.Version=$(EFFECTIVE_VERSION)' -X 'main.ImageTag=$(IMAGE_TAG)'"\
 	    ./cmd/nwpd


### PR DESCRIPTION
**What this PR does / why we need it**:
Similar to https://github.com/gardener/vpn2/pull/9. 

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/backlog/issues/19

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Container images are now built and published also for `arm64` platforms.
```
