### PR TITLE
Updated golang to v1.18.5

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -21,7 +21,7 @@ network-problem-detector:
             dockerfile: 'Dockerfile'
     steps:
       verify:
-        image: golang:1.18.2
+        image: golang:1.18.5
   jobs:
     head-update:
       traits:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ############# builder
-FROM golang:1.18.3 AS builder
+FROM golang:1.18.5 AS builder
 
 WORKDIR /build
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,6 @@ build-local:
 	@CGO_ENABLED=1 GO111MODULE=on go build -o $(EXECUTABLE) \
 	    -race \
         -mod=vendor \
-	    -gcflags="all=-N -l" \
 	    -ldflags "-X 'main.Version=$(EFFECTIVE_VERSION)' -X 'main.ImageTag=$(IMAGE_TAG)'"\
 	    ./cmd/nwpd
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Updated golang used to build image from v1.18.3 to v1.18.5

**Which issue(s) this PR fixes**:
Fixes #7

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Updated golang to v1.18.5
```
