### PR TITLE
use full qualified domain name for kubernetes service

### DIFF
--- a/pkg/agent/runners/checkhttpsget.go
+++ b/pkg/agent/runners/checkhttpsget.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/gardener/network-problem-detector/pkg/common"
 	"github.com/gardener/network-problem-detector/pkg/common/config"
 	"github.com/spf13/cobra"
 )
@@ -47,7 +48,7 @@ func (a *checkHTTPSGetArgs) createRunner(cmd *cobra.Command, args []string) erro
 		}
 	} else if a.internalKAPI {
 		endpoints = append(endpoints, config.Endpoint{
-			Hostname: "kubernetes.default.svc",
+			Hostname: common.DomainNameKubernetesService,
 			IP:       "",
 			Port:     443,
 		})

--- a/pkg/agent/runners/parser_test.go
+++ b/pkg/agent/runners/parser_test.go
@@ -7,6 +7,7 @@ package runners
 import (
 	"time"
 
+	"github.com/gardener/network-problem-detector/pkg/common"
 	"github.com/gardener/network-problem-detector/pkg/common/config"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -31,7 +32,7 @@ var _ = Describe("parser", func() {
 				{Nodename: "node2", Podname: "pod2", PodIP: "10.128.0.12", Port: 1234},
 			},
 			InternalKubeAPIServer: &config.Endpoint{
-				Hostname: "kubernetes",
+				Hostname: common.DomainNameKubernetesService,
 				IP:       "100.64.0.1",
 				Port:     443,
 			},
@@ -60,7 +61,7 @@ var _ = Describe("parser", func() {
 			{Hostname: "node2", IP: "10.128.0.12", Port: 1234},
 		}
 		endpointsInternalKubeApiServer = []config.Endpoint{
-			{Hostname: "kubernetes", IP: "100.64.0.1", Port: 443},
+			{Hostname: common.DomainNameKubernetesService, IP: "100.64.0.1", Port: 443},
 		}
 
 		endpointsKubeApiServer = []config.Endpoint{
@@ -71,10 +72,10 @@ var _ = Describe("parser", func() {
 			{Hostname: "server2", IP: "", Port: 443},
 		}
 		httpsEndpointsInternalKubeApiServer = []config.Endpoint{
-			{Hostname: "kubernetes.default.svc", IP: "", Port: 443},
+			{Hostname: common.DomainNameKubernetesService, IP: "", Port: 443},
 		}
 		dnsnames = []string{
-			"eu.gcr.io.", "foo.bar.", "kubernetes.default.svc.cluster.local.", "api.shoot.domain.com.",
+			"eu.gcr.io.", "foo.bar.", common.DomainNameKubernetesService, "api.shoot.domain.com.",
 		}
 	)
 

--- a/pkg/agent/runners/robinround.go
+++ b/pkg/agent/runners/robinround.go
@@ -52,7 +52,7 @@ func (r *robinRound[T]) Run(ch chan<- *nwpd.Observation) {
 	nodeName := GetNodeName()
 	obs := &nwpd.Observation{
 		SrcHost:   nodeName,
-		DestHost:  item.DestHost(),
+		DestHost:  normalise(item.DestHost()),
 		Timestamp: timestamppb.Now(),
 		JobID:     r.config.JobID,
 	}

--- a/pkg/common/constant.go
+++ b/pkg/common/constant.go
@@ -9,8 +9,10 @@ const (
 	NamespaceDefault = "default"
 	// NamespaceKubeSystem is the kube-system namespace
 	NamespaceKubeSystem = "kube-system"
-	// NameKubernetes is the kubernetes service name
-	NameKubernetes = "kubernetes"
+	// NameKubernetesService is the kubernetes service name
+	NameKubernetesService = "kubernetes"
+	// DomainNameKubernetesService is the Kubernetes service domain name
+	DomainNameKubernetesService = "kubernetes.default.svc.cluster.local."
 	// NameGardenerShootInfo is the name of the shoot info config map from Gardener
 	NameGardenerShootInfo = "shoot-info"
 	// AgentConfigFilename is the name of the config file

--- a/pkg/controller/watch.go
+++ b/pkg/controller/watch.go
@@ -150,13 +150,13 @@ func (cc *controllerCommand) watch(log logrus.FieldLogger) error {
 			continue
 		}
 
-		svc, err := cc.Clientset.CoreV1().Services(common.NamespaceDefault).Get(ctx, common.NameKubernetes, metav1.GetOptions{})
+		svc, err := cc.Clientset.CoreV1().Services(common.NamespaceDefault).Get(ctx, common.NameKubernetesService, metav1.GetOptions{})
 		if err != nil {
-			log.Errorf("loading service %s/%s failed: %s", common.NamespaceDefault, common.NameKubernetes, err)
+			log.Errorf("loading service %s/%s failed: %s", common.NamespaceDefault, common.NameKubernetesService, err)
 			continue
 		}
 		internalApiServer := &config.Endpoint{
-			Hostname: common.NameKubernetes,
+			Hostname: common.DomainNameKubernetesService,
 			IP:       svc.Spec.ClusterIP,
 			Port:     int(svc.Spec.Ports[0].Port),
 		}

--- a/pkg/deploy/agent.go
+++ b/pkg/deploy/agent.go
@@ -434,7 +434,7 @@ func (ac *AgentDeployConfig) buildControllerDeployment() (*appsv1.Deployment, *r
 				APIGroups:     []string{""},
 				Verbs:         []string{"get"},
 				Resources:     []string{"services"},
-				ResourceNames: []string{common.NameKubernetes},
+				ResourceNames: []string{common.NameKubernetesService},
 			},
 		},
 	}

--- a/pkg/deploy/command.go
+++ b/pkg/deploy/command.go
@@ -259,12 +259,12 @@ func (dc *deployCommand) buildAgentConfigMap() (*corev1.ConfigMap, error) {
 
 func (dc *deployCommand) buildClusterConfigMap() (*corev1.ConfigMap, error) {
 	ctx := context.Background()
-	svc, err := dc.Clientset.CoreV1().Services(common.NamespaceDefault).Get(ctx, common.NameKubernetes, metav1.GetOptions{})
+	svc, err := dc.Clientset.CoreV1().Services(common.NamespaceDefault).Get(ctx, common.NameKubernetesService, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
 	internalApiServer := &config.Endpoint{
-		Hostname: common.NameKubernetes,
+		Hostname: common.DomainNameKubernetesService,
 		IP:       svc.Spec.ClusterIP,
 		Port:     int(svc.Spec.Ports[0].Port),
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
TCP and HTTPS checks are using the full qualified domain name for kubernetes service now.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
