### PR TITLE
Timeout for TCP connection checks

### DIFF
--- a/pkg/agent/runners/checktcpport.go
+++ b/pkg/agent/runners/checktcpport.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gardener/network-problem-detector/pkg/common/config"
 	"github.com/spf13/cobra"
@@ -120,7 +121,7 @@ var _ Runner = &checkTCPPort{}
 
 func checkTCPPortFunc(endpoint config.Endpoint) (string, error) {
 	addr := fmt.Sprintf("%s:%d", endpoint.IP, endpoint.Port)
-	conn, err := net.Dial("tcp", addr)
+	conn, err := net.DialTimeout("tcp", addr, 30*time.Second)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
If TCP packets are blocked, the TCP connection tries for very long time.
A timeout of 30s is introduced to get failure reported earlier.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Timeout for TCP connection checks
```
