### PR TITLE
Add flag to disable automountServiceAccountToken for agents daemon sets

### DIFF
--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -48,3 +48,17 @@ func (s StringSet) ToSortedArray() []string {
 func FormatAsUTC(t time.Time) string {
 	return t.UTC().Format("2006-01-02T15:04:05Z")
 }
+
+// MergeMaps merges two maps. If key is contained in both maps, the value of the second map is used.
+func MergeMaps(map1, map2 map[string]string) map[string]string {
+	result := map[string]string{}
+
+	for k, v := range map1 {
+		result[k] = v
+	}
+
+	for k, v := range map2 {
+		result[k] = v
+	}
+	return result
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add flag to remove automountServiceAccountToken field for agents daemon sets.
This is needed for deployment by the Gardener extension `shoot-networking-problemdetector` to  work correctly
with the [auto mounting of projected serviceaccount tokens feature] (https://github.com/gardener/gardener/blob/eb8400a2961400a8b984252a76eb546ea44432fd/docs/concepts/resource-manager.md#auto-mounting-projected-serviceaccount-tokens)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add flag to disable automountServiceAccountToken for agents daemon sets optionally
```
