### PR TITLE
Add DefaultSeccompProfileEnabled flag and tests

### DIFF
--- a/pkg/deploy/agent_test.go
+++ b/pkg/deploy/agent_test.go
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package deploy_test
+
+import (
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/gardener/network-problem-detector/pkg/deploy"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Add default seccomp profile when enabled", func() {
+	var deployConfig *deploy.AgentDeployConfig
+
+	BeforeEach(func() {
+		deployConfig = &deploy.AgentDeployConfig{
+			Image:                    "image:tag",
+			DefaultPeriod:            16 * time.Second,
+			PodSecurityPolicyEnabled: true,
+			PingEnabled:              false,
+		}
+	})
+
+	It("should create daemonset without seccomp profile", func() {
+		objs, err := deploy.DeployNetworkProblemDetectorAgent(deployConfig)
+		Expect(err).To(BeNil())
+		Expect(len(objs)).NotTo(BeZero())
+		var ds *appsv1.DaemonSet
+		for _, obj := range objs {
+			switch v := obj.(type) {
+			case *appsv1.DaemonSet:
+				ds = v
+			}
+		}
+
+		Expect(ds).NotTo(BeNil())
+		Expect(ds.Spec.Template.Spec.SecurityContext).To(BeNil())
+	})
+
+	It("should create daemonset with seccomp profile", func() {
+		deployConfig.DefaultSeccompProfileEnabled = true
+		objs, err := deploy.DeployNetworkProblemDetectorAgent(deployConfig)
+		Expect(err).To(BeNil())
+		Expect(len(objs)).NotTo(BeZero())
+		var ds *appsv1.DaemonSet
+		for _, obj := range objs {
+			switch v := obj.(type) {
+			case *appsv1.DaemonSet:
+				ds = v
+			}
+		}
+
+		Expect(ds).NotTo(BeNil())
+		Expect(ds.Spec.Template.Spec.SecurityContext).NotTo(BeNil())
+		Expect(ds.Spec.Template.Spec.SecurityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+	})
+})

--- a/pkg/deploy/deploy_suite_test.go
+++ b/pkg/deploy/deploy_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package deploy_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestDeploy(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Deploy Suite")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new `AgentDeployConfig` flag `DefaultSeccompProfileEnabled` which when used enables seccomp profiles to be defaulted to RuntimeDefault for daemonsets pods. Tests for this new flag have been added as well.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
After these changes have been released a new PR for the shoot-networking-problemdetector extension will be made to use the new flag.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
`AgentDeployConfig` now has the option to enable seccomp profiles to be defaulted to RuntimeDefault for daemonsets pods
```
