### PR TITLE
Change default host ports to avoid collisions

### DIFF
--- a/pkg/common/constant.go
+++ b/pkg/common/constant.go
@@ -50,7 +50,7 @@ const (
 	// PodNetPodHttpPort is the port used for the metrics http server of the pods running in the pod network
 	PodNetPodHttpPort = 8881
 	// HostNetPodGRPCPort is the port used for the GRPC server of the pods running in the host network
-	HostNetPodGRPCPort = 1011
+	HostNetPodGRPCPort = 12995
 	// HostNetPodHttpPort is the port used for the metrics http server of the pods running in the host network
-	HostNetPodHttpPort = 1012
+	HostNetPodHttpPort = 12996
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
The port used by the daemon set running on the host network are changed from `1011,1012` to `12995,12996`.
The hope is that it is less likely to have clashes with other services in this higher port range
.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The port used by the daemon set running on the host network are changed from `1011,1012` to `12995,12996`.
```
