### PR TITLE
Liveness probe for HTTP port

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -411,7 +411,8 @@ func (s *server) run() {
 		http.Handle(twirpServer.PathPrefix(), twirpServer)
 
 		go func() {
-			http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
+			err := http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
+			s.log.Warnf(err.Error())
 		}()
 	}
 	if s.writer != nil {

--- a/pkg/deploy/agent.go
+++ b/pkg/deploy/agent.go
@@ -250,6 +250,13 @@ func (ac *AgentDeployConfig) buildDaemonSet(serviceAccountName string, hostNetwo
 								},
 							},
 						},
+						LivenessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								TCPSocket: &corev1.TCPSocketAction{
+									Port: intstr.FromInt(int(portHttp)),
+								},
+							},
+						},
 						Ports: []corev1.ContainerPort{
 							{
 								Name:          "metrics",


### PR DESCRIPTION
**What this PR does / why we need it**:
A liveness probe is added for the HTTP port of the NWPD agents. If no TCP socket can be opened on this port, the pod container will be restarted every 40s as a consequence.
Note that all NWPD agents perform regular checks to this port (jobs `n2p` and `p2p` for the daemon set on the pod network, `n2n` and `p2n` for the daemon set on the node network). So failure of this probe is signalling an issue with the port itself (e.g. already used by another process) and hopefully helps operators to avoid searching for network problems instead.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add liveness probe for HTTP port for NWPD daemon sets.
```
