### PR TITLE
Update builder image to `golang:1.19.5`

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -21,7 +21,7 @@ network-problem-detector:
             dockerfile: 'Dockerfile'
     steps:
       verify:
-        image: golang:1.19.4
+        image: golang:1.19.5
   jobs:
     head-update:
       traits:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ############# builder
-FROM golang:1.19.4 AS builder
+FROM golang:1.19.5 AS builder
 
 WORKDIR /build
 COPY . .

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,7 +1,3 @@
-# github.com/PuerkitoBio/purell v1.1.1
-## explicit
-# github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
-## explicit
 # github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b
 ## explicit; go 1.15
 github.com/ajstarks/svgo


### PR DESCRIPTION
**What this PR does / why we need it**:
Update builder image to `golang:1.19.5`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update builder image from `golang:1.19.4` to `golang:1.19.5`
```
