### PR TITLE
Ensure agent checks own node

### DIFF
--- a/pkg/agent/aggregation/aggregator.go
+++ b/pkg/agent/aggregation/aggregator.go
@@ -23,6 +23,8 @@ import (
 type ObsAggregationOptions struct {
 	// Log is the used logger
 	Log logrus.FieldLogger
+	// NodeName is the hostname of this node
+	NodeName string
 	// ReportPeriod is the period between two reports
 	ReportPeriod time.Duration
 	// TimeWindow is the window after which aggregations are removed if no new ones are added
@@ -292,7 +294,7 @@ func NewObsAggregator(options *ObsAggregationOptions) (*obsAggr, error) {
 	var k8sExporter types.Exporter
 	if options.K8sExporterEnabled {
 		var err error
-		k8sExporter, err = newExporter(options.Log, options.HostNetwork, options.K8sExporterHeartbeatPeriod)
+		k8sExporter, err = newExporter(options.Log, options.NodeName, options.HostNetwork, options.K8sExporterHeartbeatPeriod)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/agent/aggregation/k8s_exporter.go
+++ b/pkg/agent/aggregation/k8s_exporter.go
@@ -12,7 +12,6 @@ import (
 	"github.com/gardener/network-problem-detector/pkg/agent/aggregation/condition"
 	"github.com/gardener/network-problem-detector/pkg/agent/aggregation/problemclient"
 	"github.com/gardener/network-problem-detector/pkg/agent/aggregation/types"
-	"github.com/gardener/network-problem-detector/pkg/agent/runners"
 	"github.com/gardener/network-problem-detector/pkg/agent/version"
 	"github.com/gardener/network-problem-detector/pkg/common"
 	"github.com/sirupsen/logrus"
@@ -26,7 +25,7 @@ type k8sExporter struct {
 }
 
 // newExporter creates a exporter for Kubernetes apiserver exporting,
-func newExporter(log logrus.FieldLogger, hostNetwork bool, heartbeatPeriod time.Duration) (types.Exporter, error) {
+func newExporter(log logrus.FieldLogger, nodeName string, hostNetwork bool, heartbeatPeriod time.Duration) (types.Exporter, error) {
 	agentName := common.NameDaemonSetAgentPodNet
 	if hostNetwork {
 		agentName = common.NameDaemonSetAgentHostNet
@@ -35,7 +34,7 @@ func newExporter(log logrus.FieldLogger, hostNetwork bool, heartbeatPeriod time.
 	pco := &problemclient.ProblemClientOptions{
 		AgentName:      agentName,
 		AgentVersion:   version.Version,
-		NodeName:       runners.GetNodeName(),
+		NodeName:       nodeName,
 		EventNamespace: "",
 		KubeConfigPath: "", // in-cluster
 		Log:            log,

--- a/pkg/agent/runners/robinround.go
+++ b/pkg/agent/runners/robinround.go
@@ -45,11 +45,10 @@ func (r *robinRound[T]) DestHosts() []string {
 	return hosts
 }
 
-func (r *robinRound[T]) Run(ch chan<- *nwpd.Observation) {
+func (r *robinRound[T]) Run(nodeName string, ch chan<- *nwpd.Observation) {
 	item := r.items[r.next]
 	r.next = (r.next + 1) % len(r.items)
 
-	nodeName := GetNodeName()
 	obs := &nwpd.Observation{
 		SrcHost:   nodeName,
 		DestHost:  normalise(item.DestHost()),

--- a/pkg/agent/runners/utils.go
+++ b/pkg/agent/runners/utils.go
@@ -5,19 +5,8 @@
 package runners
 
 import (
-	"os"
 	"strings"
-
-	"github.com/gardener/network-problem-detector/pkg/common"
 )
-
-func GetNodeName() string {
-	nodeName := os.Getenv(common.EnvNodeName)
-	if nodeName == "" {
-		nodeName, _ = os.Hostname()
-	}
-	return nodeName
-}
 
 func normalise(dnsname string) string {
 	if strings.HasSuffix(dnsname, ".") {

--- a/pkg/common/config/sample.go
+++ b/pkg/common/config/sample.go
@@ -19,8 +19,8 @@ type SampleConfig struct {
 }
 
 // NewNodeSampleStore create a new node sample store
-func NewNodeSampleStore() *NodeSampleStore {
-	return &NodeSampleStore{store: map[string]float64{}}
+func NewNodeSampleStore(nodeName string) *NodeSampleStore {
+	return &NodeSampleStore{nodeName: nodeName, store: map[string]float64{}}
 }
 
 type orderedNode struct {
@@ -32,7 +32,8 @@ type orderedNode struct {
 // It allows to keep node samples as stable as possible after adding or removing nodes.
 type NodeSampleStore struct {
 	sync.Mutex
-	store map[string]float64
+	nodeName string
+	store    map[string]float64
 }
 
 // SelectTopNodes selects a stable nodes sample of the given size.
@@ -51,6 +52,9 @@ func (s *NodeSampleStore) SelectTopNodes(hostnames map[string]struct{}, size int
 		index, ok := s.store[name]
 		if !ok {
 			index = rand.Float64()
+			if name == s.nodeName {
+				index = 0 // always include own node for self-checks
+			}
 			s.store[name] = index
 		}
 		array = append(array, orderedNode{hostname: name, index: index})

--- a/pkg/common/config/sample_test.go
+++ b/pkg/common/config/sample_test.go
@@ -68,7 +68,7 @@ var _ = Describe("sample", func() {
 	It("should select all nodes if maxNodes == 0", func() {
 		sc := &config.SampleConfig{
 			MaxNodes:        0,
-			NodeSampleStore: config.NewNodeSampleStore(),
+			NodeSampleStore: config.NewNodeSampleStore("host-1"),
 		}
 
 		shuffledCC := sc.ShuffledSample(clusterCfg)
@@ -80,11 +80,20 @@ var _ = Describe("sample", func() {
 		scList := make([]*config.SampleConfig, nodeCount)
 		ccList := make([]config.ClusterConfig, nodeCount)
 		for i := 0; i < nodeCount; i++ {
+			nodeName := fmt.Sprintf("host-%d", i)
 			scList[i] = &config.SampleConfig{
 				MaxNodes:        maxNodes,
-				NodeSampleStore: config.NewNodeSampleStore(),
+				NodeSampleStore: config.NewNodeSampleStore(nodeName),
 			}
 			ccList[i] = scList[i].ShuffledSample(clusterCfg)
+			foundSelf := false
+			for _, node := range ccList[i].Nodes {
+				if node.Hostname == nodeName {
+					foundSelf = true
+					break
+				}
+			}
+			Expect(foundSelf).To(BeTrue())
 		}
 
 		distribution, total := calcNodeDistribution(ccList)
@@ -98,7 +107,7 @@ var _ = Describe("sample", func() {
 			if shouldReplaceNode(i) {
 				scList[i] = &config.SampleConfig{
 					MaxNodes:        maxNodes,
-					NodeSampleStore: config.NewNodeSampleStore(),
+					NodeSampleStore: config.NewNodeSampleStore(fmt.Sprintf("host-%d", i)),
 				}
 			}
 			ccList2[i] = scList[i].ShuffledSample(clusterCfg2)


### PR DESCRIPTION
**What this PR does / why we need it**:
With the introduction of peer node samples the node self-check has gone lost. But the self-check is useful to distinguish between local problems and real network problems. I.e. if a TCP check from a local NWPD agent to its own node fails, the cause is probably on the node and not network-related.

Additionally the global method `runners.GetNodeName()` was relocated into the server struct to reduce implicit dependencies.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
