### PR TITLE
Node conditions should not be set on check failures of few other nodes

### DIFF
--- a/pkg/agent/aggregation/k8s_exporter.go
+++ b/pkg/agent/aggregation/k8s_exporter.go
@@ -7,13 +7,12 @@
 package aggregation
 
 import (
-	"time"
-
 	"github.com/gardener/network-problem-detector/pkg/agent/aggregation/condition"
 	"github.com/gardener/network-problem-detector/pkg/agent/aggregation/problemclient"
 	"github.com/gardener/network-problem-detector/pkg/agent/aggregation/types"
 	"github.com/gardener/network-problem-detector/pkg/agent/version"
 	"github.com/gardener/network-problem-detector/pkg/common"
+	"github.com/gardener/network-problem-detector/pkg/common/config"
 	"github.com/sirupsen/logrus"
 	"k8s.io/utils/clock"
 )
@@ -25,7 +24,7 @@ type k8sExporter struct {
 }
 
 // newExporter creates a exporter for Kubernetes apiserver exporting,
-func newExporter(log logrus.FieldLogger, nodeName string, hostNetwork bool, heartbeatPeriod time.Duration) (types.Exporter, error) {
+func newExporter(log logrus.FieldLogger, nodeName string, hostNetwork bool, exporterConfig config.K8sExporterConfig) (types.Exporter, error) {
 	agentName := common.NameDaemonSetAgentPodNet
 	if hostNetwork {
 		agentName = common.NameDaemonSetAgentHostNet
@@ -47,7 +46,7 @@ func newExporter(log logrus.FieldLogger, nodeName string, hostNetwork bool, hear
 	ke := k8sExporter{
 		log:              log,
 		client:           c,
-		conditionManager: condition.NewConditionManager(log, c, clock.RealClock{}, heartbeatPeriod),
+		conditionManager: condition.NewConditionManager(log, c, clock.RealClock{}, exporterConfig.HeartbeatPeriod.Duration),
 	}
 
 	ke.conditionManager.Start()

--- a/pkg/agent/runners/internaljob.go
+++ b/pkg/agent/runners/internaljob.go
@@ -29,14 +29,16 @@ type Runner interface {
 }
 
 type InternalJob struct {
-	runner  Runner
-	active  atomic.Bool
-	lastRun atomic.Value
+	runner        Runner
+	peerNodeCount int
+	active        atomic.Bool
+	lastRun       atomic.Value
 }
 
-func NewInternalJob(runner Runner) *InternalJob {
+func NewInternalJob(runner Runner, peerNodeCount int) *InternalJob {
 	return &InternalJob{
-		runner: runner,
+		runner:        runner,
+		peerNodeCount: peerNodeCount,
 	}
 }
 
@@ -54,6 +56,10 @@ func (j *InternalJob) Config() RunnerConfig {
 
 func (j *InternalJob) Description() string {
 	return j.runner.Description()
+}
+
+func (j *InternalJob) PeerNodeCount() int {
+	return j.peerNodeCount
 }
 
 func (j *InternalJob) DestHosts() []string {

--- a/pkg/agent/runners/parser.go
+++ b/pkg/agent/runners/parser.go
@@ -46,7 +46,7 @@ func GetNewRoot(ra *runnerArgs) *cobra.Command {
 	return root
 }
 
-func Parse(clusterCfg config.ClusterConfig, config RunnerConfig, args []string, sampleCfg *config.SampleConfig) (Runner, error) {
+func Parse(clusterCfg config.ClusterConfig, config RunnerConfig, args []string, sampleCfg *config.SampleConfig) (*InternalJob, error) {
 	ra := &runnerArgs{}
 	root := GetNewRoot(ra)
 
@@ -68,5 +68,8 @@ func Parse(clusterCfg config.ClusterConfig, config RunnerConfig, args []string, 
 	if err != nil {
 		return nil, err
 	}
-	return ra.runner, nil
+	if ra.runner == nil {
+		return nil, nil
+	}
+	return NewInternalJob(ra.runner, len(ra.clusterCfg.Nodes)), nil
 }

--- a/pkg/agent/runners/parser_test.go
+++ b/pkg/agent/runners/parser_test.go
@@ -86,7 +86,7 @@ var _ = Describe("parser", func() {
 			case Runner:
 				Expect(err).To(BeNil())
 				Expect(actual.Config()).To(Equal(v.Config()))
-				Expect(actual.TestData()).To(Equal(v.TestData()))
+				Expect(actual.runner.TestData()).To(Equal(v.TestData()))
 			case string:
 				Expect(err).NotTo(BeNil())
 				Expect(err.Error()).To(ContainSubstring(v))

--- a/pkg/common/config/agent.go
+++ b/pkg/common/config/agent.go
@@ -64,4 +64,6 @@ type K8sExporterConfig struct {
 	Enabled bool `json:"enabled"`
 	// HeartbeatPeriod defines the update frequency of the node conditions.
 	HeartbeatPeriod *metav1.Duration `json:"heartbeatPeriod,omitempty"`
+	// MinFailingPeerNodeShare if > 0, reports node conditions `ClusterNetworkProblems` or `HostNetworkProblems` for node checks only if minimum share of destination peer nodes are failing. Valid range: [0.0,1.0]
+	MinFailingPeerNodeShare float64 `json:"minFailingPeerNodeShare,omitempty"`
 }

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -23,6 +23,12 @@ func (s StringSet) AddAll(keys ...string) {
 	}
 }
 
+func (s StringSet) AddSet(other StringSet) {
+	if len(other) > 0 {
+		s.AddAll(other.ToArray()...)
+	}
+}
+
 func (s StringSet) Contains(key string) bool {
 	_, ok := s[key]
 	return ok
@@ -37,11 +43,16 @@ func (s StringSet) Len() int {
 }
 
 func (s StringSet) ToSortedArray() []string {
+	list := s.ToArray()
+	sort.Strings(list)
+	return list
+}
+
+func (s StringSet) ToArray() []string {
 	list := make([]string, 0, len(s))
 	for key := range s {
 		list = append(list, key)
 	}
-	sort.Strings(list)
 	return list
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
A new command line option `--k8s-exporter-min-failing-peer-node-share` is introduced to control the behaviour of the node conditions `HostNetworkProblem` and `ClusterNetworkProblem`  if only checks to a few other nodes are failing.
Currently if a node is not reachable by TCP checks from other nodes, all other nodes are setting the node condition to `true`. Although the problem is located at the destination node, the condition is set on all checking source nodes. This is a known short-coming of the NWPD, but it could only be overcome by some central controller to reason about the whole picture. It needs more discussion if we should go in this direction as it complicates things and causes additional workload for the kube-apiserver.

With this new option, the node condition is only set if the specified percentage of the other nodes are not reachable.
I.e. the default value `0.2` means the condition is only set if  more than 20% (rounding up) of the known nodes are not reachable. The old behaviour would be restored with value `0.0`.
If checks like DNS lookups or connectivity to kube-apiserver are failing, the behaviour is unchanged, i.e. the node conditions are set as before if the issues are persistent for longer than 3 minutes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
A new command line option `--k8s-exporter-min-failing-peer-node-share` is introduced  to control the behaviour of the node conditions `HostNetworkProblem` and `ClusterNetworkProblem` if only checks to a few other nodes are failing.
```
