### PR TITLE
Exclude not-running and "ghost" agent pods from cluster-config.

### DIFF
--- a/pkg/deploy/clusterconfig.go
+++ b/pkg/deploy/clusterconfig.go
@@ -22,6 +22,7 @@ func BuildClusterConfig(nodes []*corev1.Node, agentPods []*corev1.Pod,
 		KubeAPIServer:         kubeAPIServer,
 	}
 
+	nodeNames := common.StringSet{}
 	for _, n := range nodes {
 		hostname := ""
 		ip := ""
@@ -40,9 +41,13 @@ func BuildClusterConfig(nodes []*corev1.Node, agentPods []*corev1.Pod,
 			Hostname:   hostname,
 			InternalIP: ip,
 		})
+		nodeNames.Add(hostname)
 	}
 
 	for _, p := range agentPods {
+		if p.Status.Phase != corev1.PodRunning || !nodeNames.Contains(p.Spec.NodeName) {
+			continue
+		}
 		clusterConfig.PodEndpoints = append(clusterConfig.PodEndpoints, config.PodEndpoint{
 			Nodename: p.Spec.NodeName,
 			Podname:  p.Name,


### PR DESCRIPTION
**What this PR does / why we need it**:
Not-running NWPD agent pods are not included anymore in the `network-problem-detector-cluster-config`, as checks to this pods would fail as long as it is not running. 
Additionally it also filters "ghost" pods belonging to non-existing nodes. After deleting a node without drain, the pods may still be listed for some time, until the GC of kubernetes removes them finally.
This should reduce noisy failed checks during node replacements.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Exclude not-running and "ghost" agent pods from cluster-config.
```
