### PR TITLE
Add responsibles for components and cleanup old snapshot versions.

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -3,6 +3,12 @@ network-problem-detector:
   base_definition:
     repo: ~
     traits:
+      component_descriptor:
+        component_labels:
+        - name: 'cloud.gardener.cnudie/responsibles'
+          value:
+          - type: 'codeowners'
+        retention_policy: 'clean-snapshots'
       version:
         preprocess:
           'inject-commit-hash'
@@ -35,8 +41,6 @@ network-problem-detector:
     head-update:
       traits:
         draft_release: ~
-        component_descriptor:
-          retention_policy: 'clean-snapshots'
     pull-request:
       traits:
         pull-request: ~


### PR DESCRIPTION
**What this PR does / why we need it**:
Add responsibles for components and cleanup old snapshot versions.

Furthermore, remove duplication in the build steps by moving the definition to the base.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
