### PR TITLE
Changed default rentention hours from 4 to 24, log file size restriction reduced 

### DIFF
--- a/pkg/agent/aggregation/aggregator.go
+++ b/pkg/agent/aggregation/aggregator.go
@@ -120,7 +120,7 @@ func (jea *jobEdgeAggregation) Report(je jobEdge, start time.Time) string {
 		}
 		return msg
 	}
-	seconds := int(time.Now().Sub(jea.reportStart).Seconds())
+	seconds := int(time.Now().Sub(start).Seconds())
 	return fmt.Sprintf("%s: %d/%d checks failed in last %ds (last ok: %s)", je,
 		jea.reportFailureCount, jea.reportFailureCount+jea.reportOkCount, seconds, common.FormatAsUTC(jea.okLast))
 }

--- a/pkg/common/constant.go
+++ b/pkg/common/constant.go
@@ -44,7 +44,7 @@ const (
 	// PathOutputDir path of output directory with observations in pods
 	PathOutputDir = PathLogDir + "/records"
 	// MaxLogfileSize is the maximum size of a log file written to the host file system
-	MaxLogfileSize = 10 * 1000 * 1000
+	MaxLogfileSize = 5 * 1000 * 1000
 	// PodNetPodHttpPort is the port used for the metrics http server of the pods running in the pod network
 	PodNetPodHttpPort = 8881
 	// HostNetPodHttpPort is the port used for the metrics http server of the pods running in the host network

--- a/pkg/deploy/agent.go
+++ b/pkg/deploy/agent.go
@@ -678,7 +678,7 @@ func (ac *AgentDeployConfig) BuildAgentConfig() (*config.AgentConfig, error) {
 	periodXL := fmt.Sprintf("%ds", imin(60, imax(1, int(ac.DefaultPeriod/time.Second))*2))
 	cfg := config.AgentConfig{
 		OutputDir:       common.PathOutputDir,
-		RetentionHours:  4,
+		RetentionHours:  24,
 		LogObservations: false,
 		HostNetwork: &config.NetworkConfig{
 			DataFilePrefix: common.NameDaemonSetAgentHostNet,


### PR DESCRIPTION
**What this PR does / why we need it**:
- records are kept longer on the nodes: 24 instead of 4 hours
- log files are restricted to 5 MB, formerly 10 MB (still enough to cover multiple weeks)
- fix second calculation for failed check report period

Storing records on the file system needs less than 100k per hour (for both agents together). The reduction of the log size is larger then the additional space for the records, so this change should not cause any issue.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Records are kept 24 hours on the node filesystem by default (formerly only 4 hours)
```
