### PR TITLE
Update golang to 1.20.4 in verification step

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -36,7 +36,7 @@ network-problem-detector:
                 availability_requirement: 'low'
     steps:
       verify:
-        image: golang:1.19.6
+        image: golang:1.20.4
   jobs:
     head-update:
       traits:


### PR DESCRIPTION
**What this PR does / why we need it**:
Update golang to 1.20.4 in verification step.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
The golang version in `Dockerfile` and `go.mod` were already increased previously.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
