### PR TITLE
Fix/trigger update on apiserver address change

### DIFF
--- a/pkg/controller/watch.go
+++ b/pkg/controller/watch.go
@@ -243,6 +243,10 @@ func (w *watch) Start(ctx context.Context) error {
 			continue
 		}
 		cfg, err = deploy.BuildClusterConfig(nodes, pods, internalApiServer, apiServer)
+		if err != nil {
+			w.log.Errorf("building cluster config failed: %w", err)
+			continue
+		}
 		cfgBytes, err := yaml.Marshal(cfg)
 		if err != nil {
 			w.log.Errorf("marshal configmap %s/%s failed: %s", common.NamespaceKubeSystem, common.NameClusterConfigMap, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix/trigger update on `kube-apiserver` address change.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
The second commit adds unrelated missing error handling, which was found when implementing the fix.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Cluster configuration of network problem detector is now updated when kube-apiserver's ip address changes.
```
