### PR TITLE
switch GCR -> Artifact-Registry

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -2,6 +2,8 @@ network-problem-detector:
   base_definition:
     traits:
       component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
+        component_name: 'github.com/gardener/network-problem-detector'
         component_labels:
         - name: 'cloud.gardener.cnudie/responsibles'
           value:
@@ -20,7 +22,7 @@ network-problem-detector:
             inputs:
               repos:
                 source: ~ # default
-            image: 'eu.gcr.io/gardener-project/gardener/network-problem-detector'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/network-problem-detector
             dockerfile: 'Dockerfile'
             resource_labels:
             - name: 'gardener.cloud/cve-categorisation'
@@ -37,6 +39,9 @@ network-problem-detector:
   jobs:
     head-update:
       traits:
+        component_descriptor:
+          ocm_repository_mappings:
+            - repository: europe-docker.pkg.dev/gardener-project/releases
         draft_release: ~
     pull-request:
       traits:
@@ -54,4 +59,4 @@ network-problem-detector:
               channel_name: 'C9CEBQPGE' #sap-tech-gardener
               slack_cfg_name: 'scp_workspace'
         component_descriptor:
-          component_name: 'github.com/gardener/network-problem-detector'
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,7 +1,5 @@
 network-problem-detector:
-  template: 'default'
   base_definition:
-    repo: ~
     traits:
       component_descriptor:
         component_labels:
@@ -22,7 +20,6 @@ network-problem-detector:
             inputs:
               repos:
                 source: ~ # default
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/network-problem-detector'
             dockerfile: 'Dockerfile'
             resource_labels:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-REGISTRY              := eu.gcr.io/gardener-project
+REGISTRY              := europe-docker.pkg.dev/gardener-project/public
 EXECUTABLE            := nwpdcli
 PROJECT               := github.com/gardener/network-problem-detector
 IMAGE_REPOSITORY      := $(REGISTRY)/gardener/network-problem-detector

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ To examine the current default configuration, run the command
 | Job ID            | Job Type        | Description                                                                                                                                                           |
 |-------------------|-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `https-n2api-ext` | `checkHTTPSGet` | HTTPS Get check from all pods of the daemon set of the host network to the external address of the Kube API server.                                                   |
-| `nslookup-n`      | `nslookup`      | DNS Lookup of IP addresses for the domain name `eu.gcr.io`, and external name of Kube API server.                                                                     |
+| `nslookup-n`      | `nslookup`      | DNS Lookup of IP addresses for the domain name `europe-docker.pkg.dev`, and external name of Kube API server.                                                                     |
 | `tcp-n2api-ext`   | `checkTCPPort`  | TCP connection check from all pods of the daemon set of the host network to the external address of the Kube API server.                                              |
 | `tcp-n2api-int`   | `checkTCPPort`  | TCP connection check from all pods of the daemon set of the host network to the internal address of the Kube API server.                                              |
 | `tcp-n2n`         | `checkTCPPort`  | TCP connection check from all pods of the daemon set of the host network to the node port used by the NWPD agent on the host network.                                 |
@@ -217,7 +217,7 @@ The job IDs of the default configuration on the host (=node) network are using t
 |-------------------|-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `https-p2api-ext` | `checkHTTPSGet` | HTTPS Get check from all pods of the daemon set on the cluster network to the external address of the Kube API server.                                                |
 | `https-p2api-int` | `checkHTTPSGet` | HTTPS Get check from all pods of the daemon set on the cluster network to the internal address of the Kube API server (`kubernetes.default.svc.cluster.local.:443`).      |
-| `nslookup-p`      | `nslookup`      | Lookup of IP addresses for external DNS name `eu.gcr.io`, and internal and external names of Kube API server.                                                         |
+| `nslookup-p`      | `nslookup`      | Lookup of IP addresses for external DNS name `europe-docker.pkg.dev`, and internal and external names of Kube API server.                                                         |
 | `tcp-p2api-ext`   | `checkTCPPort`  | TCP connection check from all pods of the daemon set on the cluster network to the external address of the Kube API server.                                               |
 | `tcp-p2api-int`   | `checkTCPPort`  | TCP connection check from all pods of the daemon set of the cluster network to the internal address of the Kube API server.                                              |
 | `tcp-p2n`         | `checkTCPPort`  | TCP connection check from all pods of the daemon set of the cluster network to the node port used by the NWPD agent on the host network.                                 |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ nodes and pods in the kube-system namespace. As soon as a kubelet discovers thes
 
 The results of the checks are stored locally on the node filesystem for later inspection with the `nwpdcli` command line tool.
 Additionally they are also exposed as metrics for scrapping by Prometheus.
-By enabling the `K8s exporter`, the agents periodically patch the node conditions `ClusterNetworkProblem` and `HostNetworkProblem` in 
+By enabling the `K8s exporter`, the agents periodically patch the node conditions `ClusterNetworkProblem` and `HostNetworkProblem` in
 the status of the node resources. If checks are failing, a summarising event is created too.
 The `K8s exporter` is the only part of the agent which talks to the kube-apiserver.
 
@@ -40,9 +40,9 @@ To get started, the Network Problem Detector is deployed without integration wit
 
 *Side remark:*
 
-This is the fatest way to get started with NWPD. In a productive environment, you may prefer to scrap the check results 
-using [Prometheus](https://prometheus.io/) from metrics HTTP endpoints 
-exposed by the agent pods. You may still follow this stand-alone installation, but 
+This is the fatest way to get started with NWPD. In a productive environment, you may prefer to scrap the check results
+using [Prometheus](https://prometheus.io/) from metrics HTTP endpoints
+exposed by the agent pods. You may still follow this stand-alone installation, but
 you will need additional configuration on the Prometheus side which is not covered here.
 For more details see [Access check results by Prometheus metrics](#access-check-results-by-prometheus-metrics) below.
 
@@ -73,13 +73,13 @@ Follow these steps to deploy NWPD to a Kubernetes cluster:
 4. Optional: In a second shell run the controller to update the configuration on changes of nodes and pod endpoints of the pod network daemon set with
 
    ```bash
-   ./nwpdcli run-controller 
+   ./nwpdcli run-controller
    ```
 
    Alternatively install the agent controller with
 
    ```bash
-   ./nwpdcli deploy controller 
+   ./nwpdcli deploy controller
    ```
 
 6. Collect the observations from all nodes with
@@ -187,7 +187,7 @@ To examine the current default configuration, run the command
 
 4. `nslookup [--period <duration>] [--scale-period] [--names host1,host2,...] [--name-internal-kube-apiserver"] [--name-external-kube-apiserver]`
 
-   Looks up hosts using the local resolver of the pod or the node (for agents running in the host network). 
+   Looks up hosts using the local resolver of the pod or the node (for agents running in the host network).
 
 5. `pingHost [--period <duration>] [--scale-period] [--hosts <host1:ip1>,<host2:ip2>,...]`
 
@@ -206,7 +206,7 @@ To examine the current default configuration, run the command
 | `tcp-n2api-ext`   | `checkTCPPort`  | TCP connection check from all pods of the daemon set of the host network to the external address of the Kube API server.                                              |
 | `tcp-n2api-int`   | `checkTCPPort`  | TCP connection check from all pods of the daemon set of the host network to the internal address of the Kube API server.                                              |
 | `tcp-n2n`         | `checkTCPPort`  | TCP connection check from all pods of the daemon set of the host network to the node port used by the NWPD agent on the host network.                                 |
-| `tcp-n2p`         | `checkTCPPort`  | TCP connection check from all pods of the daemon set of the host network to pod endpoints (pod IP, port of GRPC server) of the daemon set running in the pod network. | 
+| `tcp-n2p`         | `checkTCPPort`  | TCP connection check from all pods of the daemon set of the host network to pod endpoints (pod IP, port of GRPC server) of the daemon set running in the pod network. |
 
 The job IDs of the default configuration on the host (=node) network are using the naming convention `<jobtype-shortcut>-n[2<destination>][-(int|ext)]`.
 
@@ -221,6 +221,6 @@ The job IDs of the default configuration on the host (=node) network are using t
 | `tcp-p2api-ext`   | `checkTCPPort`  | TCP connection check from all pods of the daemon set on the cluster network to the external address of the Kube API server.                                               |
 | `tcp-p2api-int`   | `checkTCPPort`  | TCP connection check from all pods of the daemon set of the cluster network to the internal address of the Kube API server.                                              |
 | `tcp-p2n`         | `checkTCPPort`  | TCP connection check from all pods of the daemon set of the cluster network to the node port used by the NWPD agent on the host network.                                 |
-| `tcp-p2p`         | `checkTCPPort`  | TCP connection check from all pods of the daemon set of the cluster network to pod endpoints (pod IP, port of GRPC server) of the daemon set running in the pod network. | 
+| `tcp-p2p`         | `checkTCPPort`  | TCP connection check from all pods of the daemon set of the cluster network to pod endpoints (pod IP, port of GRPC server) of the daemon set running in the pod network. |
 
 The job IDs of the default configuration on the cluster (=pod) network are using the naming convention `<jobtype-shortcut>-p[2<destination>][-(int|ext)]`.

--- a/pkg/deploy/DEFAULT_REPOSITORY
+++ b/pkg/deploy/DEFAULT_REPOSITORY
@@ -1,1 +1,1 @@
-eu.gcr.io/gardener-project/gardener/network-problem-detector
+europe-docker.pkg.dev/gardener-project/public/gardener/network-problem-detector

--- a/pkg/deploy/agent.go
+++ b/pkg/deploy/agent.go
@@ -699,7 +699,7 @@ func (ac *AgentDeployConfig) BuildAgentConfig() (*config.AgentConfig, error) {
 				},
 				{
 					JobID: "nslookup-n",
-					Args:  []string{"nslookup", "--names", "eu.gcr.io.", "--scale-period"},
+					Args:  []string{"nslookup", "--names", "europe-docker.pkg.dev.", "--scale-period"},
 				},
 			},
 		},
@@ -726,7 +726,7 @@ func (ac *AgentDeployConfig) BuildAgentConfig() (*config.AgentConfig, error) {
 				},
 				{
 					JobID: "nslookup-p",
-					Args:  []string{"nslookup", "--names", "eu.gcr.io.", "--name-internal-kube-apiserver", "--scale-period"},
+					Args:  []string{"nslookup", "--names", "europe-docker.pkg.dev.", "--name-internal-kube-apiserver", "--scale-period"},
 				},
 			},
 		},


### PR DESCRIPTION
GCR has been deprecated [0] in favour of Artifact-Registry.

Thus, change push-targets for OCI-Images:

- europe-docker.pkg.dev/gardener-project/snapshots for snapshots
- europe-docker.pkg.dev/gardener-project/releases for releases
- europe-docker.pkg.dev/gardener-project/public for combined view of snapshots + releases

[0]
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr


**Release note**:

```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.

```
