### PR TITLE
Drop CPU limit for agents

### DIFF
--- a/pkg/deploy/agent.go
+++ b/pkg/deploy/agent.go
@@ -152,7 +152,6 @@ func (ac *AgentDeployConfig) getNetworkConfig(hostnetwork bool) (name string, po
 func (ac *AgentDeployConfig) buildDaemonSet(serviceAccountName string, hostNetwork bool) (*appsv1.DaemonSet, error) {
 	var (
 		requestCPU, _          = resource.ParseQuantity("10m")
-		limitCPU, _            = resource.ParseQuantity("50m")
 		requestMemory, _       = resource.ParseQuantity("32Mi")
 		limitMemory, _         = resource.ParseQuantity("64Mi")
 		defaultMode      int32 = 0o444
@@ -273,7 +272,6 @@ func (ac *AgentDeployConfig) buildDaemonSet(serviceAccountName string, hostNetwo
 								corev1.ResourceMemory: requestMemory,
 							},
 							Limits: corev1.ResourceList{
-								corev1.ResourceCPU:    limitCPU,
 								corev1.ResourceMemory: limitMemory,
 							},
 						},


### PR DESCRIPTION
**What this PR does / why we need it**:
Drop CPU limit for agents to avoid false alarms about throttling.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Drop CPU limit for agents
```
