### PR TITLE
Allow nodes without hostname

### DIFF
--- a/pkg/controller/watch.go
+++ b/pkg/controller/watch.go
@@ -251,7 +251,7 @@ func (w *watch) Start(ctx context.Context) error {
 			w.log.Errorf("unmarshal configmap %s/%s failed: %s", common.NamespaceKubeSystem, common.NameClusterConfigMap, err)
 			continue
 		}
-		cfg, err = deploy.BuildClusterConfig(nodes, pods, internalAPIServer, apiServer)
+		cfg, err = deploy.BuildClusterConfig(w.log, nodes, pods, internalAPIServer, apiServer)
 		if err != nil {
 			w.log.Errorf("building cluster config failed: %w", err)
 			continue

--- a/pkg/deploy/command.go
+++ b/pkg/deploy/command.go
@@ -155,11 +155,11 @@ func (dc *deployCommand) deployAgent(log logrus.FieldLogger, hostnetwork bool,
 	if err != nil {
 		return fmt.Errorf("error building service[%t]: %s", hostnetwork, err)
 	}
-	acm, err := buildAgentConfigMap()
+	acm, err := buildAgentConfigMap(log)
 	if err != nil {
 		return fmt.Errorf("error building config map: %s", err)
 	}
-	ccm, err := buildClusterConfigMap()
+	ccm, err := buildClusterConfigMap(log)
 	if err != nil {
 		return fmt.Errorf("error building config map: %s", err)
 	}
@@ -239,7 +239,7 @@ func (dc *deployCommand) deleteSecurityObjects(log logrus.FieldLogger) error {
 	return nil
 }
 
-func (dc *deployCommand) buildAgentConfigMap() (*corev1.ConfigMap, error) {
+func (dc *deployCommand) buildAgentConfigMap(_ logrus.FieldLogger) (*corev1.ConfigMap, error) {
 	agentConfig, err := dc.agentDeployConfig.BuildAgentConfig()
 	if err != nil {
 		return nil, err
@@ -247,7 +247,7 @@ func (dc *deployCommand) buildAgentConfigMap() (*corev1.ConfigMap, error) {
 	return BuildAgentConfigMap(agentConfig)
 }
 
-func (dc *deployCommand) buildClusterConfigMap() (*corev1.ConfigMap, error) {
+func (dc *deployCommand) buildClusterConfigMap(log logrus.FieldLogger) (*corev1.ConfigMap, error) {
 	ctx := context.Background()
 	svc, err := dc.Clientset.CoreV1().Services(common.NamespaceDefault).Get(ctx, common.NameKubernetesService, metav1.GetOptions{})
 	if err != nil {
@@ -278,7 +278,7 @@ func (dc *deployCommand) buildClusterConfigMap() (*corev1.ConfigMap, error) {
 		return nil, err
 	}
 
-	clusterConfig, err := BuildClusterConfig(nodes, agentPods, internalAPIServer, apiServer)
+	clusterConfig, err := BuildClusterConfig(log, nodes, agentPods, internalAPIServer, apiServer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/deploy/object.go
+++ b/pkg/deploy/object.go
@@ -23,7 +23,7 @@ type Object interface {
 	metav1.Object
 }
 
-type buildObject[T Object] func() (T, error)
+type buildObject[T Object] func(log logrus.FieldLogger) (T, error)
 
 type ObjectInterface[T Object] interface {
 	Create(ctx context.Context, obj T, opts metav1.CreateOptions) (T, error)


### PR DESCRIPTION
**What this PR does / why we need it**:
Building the cluster config was assuming that nodes always have both `InternalIP` and `Hostname` addresses in the `Node` status. The assumption has been dropped to ignore nodes without `InternalIP` address. If `Hostname` is not set, the node name is used as fallback. The `Hostname` is only used for display purposes anyway.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Allow nodes without hostname
```
