### PR TITLE
Introduce gosec for Static Application Security Testing (SAST)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ collected-observations/
 .vscode/
 nwpdcli
 *.obs/
+
+# gosec
+gosec-report.sarif

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,8 +1,7 @@
 # options for analysis running
 run:
   timeout: 2m
-  skip-files:
-  - "zz_generated.*"
+
 linters:
   enable:
   - gocritic
@@ -24,6 +23,8 @@ linters-settings:
     local-prefixes: github.com/gardener/network-problem-detector
 
 issues:
+  exclude-files:
+  - "zz_generated.*"
   exclude-rules:
   # dot imports in test files and utilities
   - path: ".*test.*.go$"

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ tidy:
 	go mod tidy
 
 .PHONY: check
-check: $(GOIMPORTS) $(GOLANGCI_LINT)
+check: $(GOIMPORTS) $(GOLANGCI_LINT) sast-report
 	go vet ./...
 	GOIMPORTS=$(GOIMPORTS) GOLANGCI_LINT=$(GOLANGCI_LINT) hack/check.sh ./cmd/... ./pkg/...
 
@@ -76,3 +76,12 @@ prepare-default-image:
 .PHONY: docker-images
 docker-images:
 	@docker build -t $(IMAGE_REPOSITORY):$(IMAGE_TAG) -f Dockerfile .
+
+.PHONY: sast
+sast: $(GOSEC)
+	@./hack/sast.sh
+
+.PHONY: sast-report
+sast-report: $(GOSEC)
+	@./hack/sast.sh --gosec-report true
+

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ tidy:
 	go mod tidy
 
 .PHONY: check
-check: $(GOIMPORTS) $(GOLANGCI_LINT) sast-report
+check: $(GOIMPORTS) $(GOLANGCI_LINT) sast
 	go vet ./...
 	GOIMPORTS=$(GOIMPORTS) GOLANGCI_LINT=$(GOLANGCI_LINT) hack/check.sh ./cmd/... ./pkg/...
 

--- a/hack/sast.sh
+++ b/hack/sast.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+
+root_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
+
+gosec_report="false"
+gosec_report_parse_flags=""
+
+parse_flags() {
+  while test $# -gt 1; do
+    case "$1" in
+      --gosec-report)
+        shift; gosec_report="$1"
+        ;;
+      *)
+        echo "Unknown argument: $1"
+        exit 1
+        ;;
+    esac
+    shift
+  done
+}
+
+parse_flags "$@"
+
+echo "> Running gosec"
+gosec --version
+if [[ "$gosec_report" != "false" ]]; then
+  echo "Exporting report to $root_dir/gosec-report.sarif"
+  gosec_report_parse_flags="-track-suppressions -fmt=sarif -out=gosec-report.sarif -stdout"
+fi
+
+# Gardener uses code-generators https://github.com/kubernetes/code-generator and https://github.com/protocolbuffers/protobuf
+# which create lots of G103 (CWE-242: Use of unsafe calls should be audited) & G104 (CWE-703: Errors unhandled) errors.
+# However, those generators are best-pratice in Kubernetes environment and their results are tested well.
+# Thus, generated code is excluded from gosec scan.
+# Nested go modules are not supported by gosec (see https://github.com/securego/gosec/issues/501), so the ./hack folder
+# is excluded too. It does not contain productive code anyway.
+gosec -exclude-generated -exclude-dir=hack $gosec_report_parse_flags ./...

--- a/hack/tools/install-gosec.sh
+++ b/hack/tools/install-gosec.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+echo "> Installing gosec"
+
+TOOLS_BIN_DIR=${TOOLS_BIN_DIR:-$(dirname $0)/bin}
+
+platform=$(uname -s | tr '[:upper:]' '[:lower:]')
+version=$GOSEC_VERSION
+case $(uname -m) in
+  aarch64 | arm64)
+    arch="arm64"
+    ;;
+  x86_64)
+    arch="amd64"
+    ;;
+  *)
+    echo "Unknown architecture"
+    exit -1
+    ;;
+esac
+
+archive_name="gosec_${version#v}_${platform}_${arch}"
+file_name="${archive_name}.tar.gz"
+
+temp_dir="$(mktemp -d)"
+function cleanup {
+  rm -rf "${temp_dir}"
+}
+trap cleanup EXIT ERR INT TERM
+
+curl -L -o ${temp_dir}/${file_name} "https://github.com/securego/gosec/releases/download/${version}/${file_name}"
+
+tar -xzm -C "${temp_dir}" -f "${temp_dir}/${file_name}"
+mv "${temp_dir}/gosec" $TOOLS_BIN_DIR
+chmod +x $TOOLS_BIN_DIR/gosec

--- a/hack/tools/tools.mk
+++ b/hack/tools/tools.mk
@@ -37,7 +37,7 @@ clean-tools-bin:
 
 # default tool versions
 # renovate: datasource=github-releases depName=golangci/golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.55.1
+GOLANGCI_LINT_VERSION ?= v1.61.0
 # renovate: datasource=github-releases depName=securego/gosec
 GOSEC_VERSION ?= v2.20.0
 

--- a/hack/tools/tools.mk
+++ b/hack/tools/tools.mk
@@ -3,8 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 TOOLS_BIN_DIR              := $(TOOLS_DIR)/bin
+export PATH := $(abspath $(TOOLS_BIN_DIR)):$(PATH)
 GOIMPORTS                  := $(TOOLS_BIN_DIR)/goimports
 GOLANGCI_LINT              := $(TOOLS_BIN_DIR)/golangci-lint
+GOSEC                      := $(TOOLS_BIN_DIR)/gosec
 
 #########################################
 # Common                                #
@@ -34,7 +36,10 @@ clean-tools-bin:
 	rm -rf $(TOOLS_BIN_DIR)/*
 
 # default tool versions
+# renovate: datasource=github-releases depName=golangci/golangci-lint
 GOLANGCI_LINT_VERSION ?= v1.55.1
+# renovate: datasource=github-releases depName=securego/gosec
+GOSEC_VERSION ?= v2.20.0
 
 GOIMPORTS_VERSION ?= $(call version_gomod,golang.org/x/tools)
 
@@ -45,3 +50,6 @@ $(GOLANGCI_LINT): $(call tool_version_file,$(GOLANGCI_LINT),$(GOLANGCI_LINT_VERS
 	@# CGO_ENABLED has to be set to 1 in order for golangci-lint to be able to load plugins
 	@# see https://github.com/golangci/golangci-lint/issues/1276
 	GOBIN=$(abspath $(TOOLS_BIN_DIR)) CGO_ENABLED=1 go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+
+$(GOSEC): $(call tool_version_file,$(GOSEC),$(GOSEC_VERSION))
+	@GOSEC_VERSION=$(GOSEC_VERSION) $(TOOLS_DIR)/install-gosec.sh

--- a/pkg/agent/aggregation/aggregator.go
+++ b/pkg/agent/aggregation/aggregator.go
@@ -319,7 +319,7 @@ var _ ObservationListenerExtended = &obsAggr{}
 
 func NewObsAggregator(options *ObsAggregationOptions) (ObservationListenerExtended, error) {
 	if options.LogDirectory != "" {
-		err := os.MkdirAll(options.LogDirectory, 0o777)
+		err := os.MkdirAll(options.LogDirectory, 0o750) //  #nosec G302 -- no sensitive data
 		if err != nil {
 			return nil, err
 		}
@@ -498,7 +498,7 @@ func (a *obsAggr) reportToFilesystem(report *reportData) {
 			a.log.Warnf("cannot rename %s to %s: %s", filename, old, err)
 		}
 	}
-	f, err := os.OpenFile(filename, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	f, err := os.OpenFile(filename, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o640) //  #nosec G302 G304 -- no sensitive data
 	if err != nil {
 		a.log.Warnf("cannot open %s: %s", filename, err)
 		return

--- a/pkg/agent/aggregation/aggregator.go
+++ b/pkg/agent/aggregation/aggregator.go
@@ -298,14 +298,14 @@ func (cs *conditionStatus) report(peerNodeCount int) types.Condition {
 	return condition
 }
 
-func toRestrictedList(set common.StringSet, max int) string {
+func toRestrictedList(set common.StringSet, maxItems int) string {
 	array := set.ToSortedArray()
 	if len(array) == 1 {
 		return array[0]
 	}
 	n := len(array)
-	if n > max {
-		n = max
+	if n > maxItems {
+		n = maxItems
 	}
 	s := "(" + strings.Join(array[:n], ",")
 	if n < len(array) {

--- a/pkg/agent/db/writer2.go
+++ b/pkg/agent/db/writer2.go
@@ -65,7 +65,7 @@ func (wf *writeFile) Persist(obj *IntString) error {
 var _ nwpd.ObservationWriter = &obsWriter{}
 
 func NewObsWriter(log logrus.FieldLogger, directory, prefix string, retentionHours int) (nwpd.ObservationWriter, error) {
-	err := os.MkdirAll(directory, 0o777)
+	err := os.MkdirAll(directory, 0o750) //  #nosec G302 -- no sensitive data
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +177,7 @@ func readRecord(r io.Reader) (byte, []byte, error) {
 }
 
 func (w *obsWriter) loadStringIDMap(filename string) (*StringIDMap, error) {
-	f, err := os.OpenFile(filename, os.O_RDONLY, 0o644)
+	f, err := os.OpenFile(filename, os.O_RDONLY, 0o640) //  #nosec G302 G304 -- no sensitive data
 	if err != nil {
 		if os.IsNotExist(err) {
 			return NewStringIDMap(), nil
@@ -238,7 +238,7 @@ func (w *obsWriter) getFile() (*writeFile, error) {
 		if err != nil {
 			return nil, err
 		}
-		f, err := os.OpenFile(filename, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+		f, err := os.OpenFile(filename, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o640) //  #nosec G302 G304 -- no sensitive data
 		if err != nil {
 			return nil, err
 		}
@@ -418,7 +418,7 @@ func GetAnyRecordFiles(directory string, subdir bool) ([]string, error) {
 type ObservationVisitor func(obs *nwpd.Observation) error
 
 func IterateRecordFile(filename string, visitor ObservationVisitor) error {
-	f, err := os.OpenFile(filename, os.O_RDONLY, 0o644)
+	f, err := os.OpenFile(filename, os.O_RDONLY, 0o640) //  #nosec G302 G304 -- no sensitive data
 	if err != nil {
 		return err
 	}

--- a/pkg/agent/runners/checkhttpsget.go
+++ b/pkg/agent/runners/checkhttpsget.go
@@ -107,7 +107,7 @@ var _ Runner = &checkHTTPSGet{}
 
 func checkHTTPSGetFunc(endpoint config.Endpoint) (string, error) {
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec G402 -- connection check only, no sensitive data
 	}
 	client := &http.Client{Transport: tr}
 	url := fmt.Sprintf("https://%s:%d", endpoint.Hostname, endpoint.Port)

--- a/pkg/agent/runners/checktcpport.go
+++ b/pkg/agent/runners/checktcpport.go
@@ -127,6 +127,6 @@ func checkTCPPortFunc(endpoint config.Endpoint) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	conn.Close()
+	_ = conn.Close()
 	return "connected", nil
 }

--- a/pkg/aggregate/command.go
+++ b/pkg/aggregate/command.go
@@ -305,7 +305,7 @@ func (ac *aggrCommand) printJobResultLine(src, dest string, jr *results) {
 }
 
 func (ac *aggrCommand) writeOpenMetricsFile(jobs, srcNodes, destNodes []string, startUnixSecs, bucketMillis int64, data map[edge]*edgeData) error {
-	f, err := os.OpenFile(ac.openMetricsOutput, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o755)
+	f, err := os.OpenFile(ac.openMetricsOutput, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o750) //  #nosec G302 -- no sensitive data
 	if err != nil {
 		return err
 	}
@@ -401,7 +401,7 @@ func (ac *aggrCommand) writeMetrics(f *os.File, name, metricsType, description s
 }
 
 func (ac *aggrCommand) writeSVGFile(jobs, srcNodes, destNodes []string, data map[edge]*edgeData) error {
-	f, err := os.OpenFile(ac.svgOutput, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o755)
+	f, err := os.OpenFile(ac.svgOutput, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o750) //  #nosec G302 -- no sensitive data
 	if err != nil {
 		return err
 	}

--- a/pkg/collect/command.go
+++ b/pkg/collect/command.go
@@ -54,7 +54,7 @@ func CreateCollectCmd() *cobra.Command {
 func (cc *collectCommand) collect(_ *cobra.Command, _ []string) error {
 	log := logrus.WithField("cmd", "collect")
 
-	if err := os.MkdirAll(cc.directory, 0o755); err != nil {
+	if err := os.MkdirAll(cc.directory, 0o750); err != nil { //  #nosec G302 -- no sensitive data
 		return err
 	}
 
@@ -113,14 +113,14 @@ func (cc *collectCommand) loadFrom(log logrus.FieldLogger, dir string, pod *core
 	if cc.Kubeconfig != "" {
 		kubeconfigOpt = " --kubeconfig=" + cc.Kubeconfig
 	}
-	if err := os.Mkdir(dir, 0o755); err != nil {
+	if err := os.Mkdir(dir, 0o750); err != nil { //  #nosec G302 -- no sensitive data
 		log.Errorf("mkdir tmpsubdir failed: %s", err)
 		cc.failedNodes.Inc()
 		return
 	}
 	cmdline := fmt.Sprintf("kubectl %s -n %s exec %s -- /nwpdcli run-collect | tar xfz - -C %s", kubeconfigOpt, pod.Namespace, pod.Name, dir)
 	var stderr bytes.Buffer
-	cmd := exec.Command("sh", "-c", cmdline)
+	cmd := exec.Command("sh", "-c", cmdline) //  #nosec G204 -- only used in interactive shell
 	cmd.Stderr = &stderr
 	cmd.Env = os.Environ()
 	err := cmd.Run()
@@ -142,7 +142,7 @@ func (cc *collectCommand) loadFrom(log logrus.FieldLogger, dir string, pod *core
 	}
 
 	outdir := path.Join(cc.directory, pod.Spec.NodeName)
-	if err := os.MkdirAll(outdir, 0o755); err != nil {
+	if err := os.MkdirAll(outdir, 0o750); err != nil { //  #nosec G302 -- no sensitive data
 		log.Errorf("mkdir failed: %s", err)
 		cc.failedNodes.Inc()
 		return
@@ -174,13 +174,13 @@ func (cc *collectCommand) loadFrom(log logrus.FieldLogger, dir string, pod *core
 }
 
 func copyFile(srcFilename, destFilename string) (int64, error) {
-	input, err := os.Open(srcFilename)
+	input, err := os.Open(srcFilename) // #nosec G304
 	if err != nil {
 		return 0, err
 	}
 	defer input.Close()
 
-	output, err := os.Create(destFilename)
+	output, err := os.Create(destFilename) // #nosec G304
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/collect/command_run.go
+++ b/pkg/collect/command_run.go
@@ -71,7 +71,7 @@ func createArchive(dir string, filenames []string, buf io.Writer) error {
 }
 
 func addFileToArchive(tw *tar.Writer, filename string) error {
-	file, err := os.Open(filename)
+	file, err := os.Open(filename) // #nosec G304
 	if err != nil {
 		return err
 	}

--- a/pkg/common/config/sample.go
+++ b/pkg/common/config/sample.go
@@ -51,7 +51,7 @@ func (s *NodeSampleStore) SelectTopNodes(hostnames map[string]struct{}, size int
 	for name := range hostnames {
 		index, ok := s.store[name]
 		if !ok {
-			index = rand.Float64()
+			index = rand.Float64() // #nosec G404 -- no cryptographic use
 			if name == s.nodeName {
 				index = 0 // always include own node for self-checks
 			}

--- a/pkg/common/config/utils.go
+++ b/pkg/common/config/utils.go
@@ -17,7 +17,7 @@ import (
 var DisableShuffleForTesting = false
 
 func LoadAgentConfig(configFile string) (*AgentConfig, error) {
-	data, err := os.ReadFile(configFile)
+	data, err := os.ReadFile(configFile) // #nosec G304
 	if err != nil {
 		return nil, err
 	}
@@ -31,7 +31,7 @@ func LoadAgentConfig(configFile string) (*AgentConfig, error) {
 }
 
 func LoadClusterConfig(configFile string) (*ClusterConfig, error) {
-	data, err := os.ReadFile(configFile)
+	data, err := os.ReadFile(configFile) // #nosec G304
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/list/command.go
+++ b/pkg/list/command.go
@@ -96,7 +96,7 @@ func (lc *listCommand) list(_ *cobra.Command, args []string) error {
 	log.Infof("Loading observations from pod %s", podname)
 	cmdline := fmt.Sprintf("kubectl %s -n kube-system  port-forward %s %d:%d", kubeconfigOpt, podname, port, targetPort)
 	var stderr bytes.Buffer
-	cmd := exec.Command("sh", "-c", cmdline)
+	cmd := exec.Command("sh", "-c", cmdline)              //  #nosec G204 -- only used in interactive shell
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true} // create process group for child processes
 	cmd.Stderr = &stderr
 	cmd.Env = os.Environ()


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces gosec for Static Application Security Testing at Gardener and should replace other code scanners.

It uses the default ruleset of gosec from gardener/gardener as introduced in https://github.com/gardener/gardener/pull/9959.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
`gosec` was introduced for Static Application Security Testing (SAST).
```
