### PR TITLE
support also checks for ipv6 endpoints

### DIFF
--- a/pkg/agent/runners/checktcpport.go
+++ b/pkg/agent/runners/checktcpport.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gardener/network-problem-detector/pkg/common/config"
 
 	"github.com/spf13/cobra"
+	k8snetutils "k8s.io/utils/net"
 )
 
 type checkTCPPortArgs struct {
@@ -123,6 +124,9 @@ var _ Runner = &checkTCPPort{}
 
 func checkTCPPortFunc(endpoint config.Endpoint) (string, error) {
 	addr := fmt.Sprintf("%s:%d", endpoint.IP, endpoint.Port)
+	if k8snetutils.IsIPv6(net.ParseIP(endpoint.IP)) {
+		addr = fmt.Sprintf("[%s]:%d", endpoint.IP, endpoint.Port)
+	}
 	conn, err := net.DialTimeout("tcp", addr, 30*time.Second)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
**What this PR does / why we need it**:
Support tcp checks for ipv6 endpoints.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
After that changes, tests are successfully executed for an ipv6 shoot cluster.
```
time="2024-10-15T09:04:11Z" level=info msg="Report: SourceHost: ok/unknown/failed: 1/0/1 (failed items: i-0c014b64770a21fe7.eu-west-1.compute.internal)" cmd=agent sub=aggr
time="2024-10-15T09:04:11Z" level=info msg="Report: DestHost: ok/unknown/failed: 5/0/2 (failed items: i-064754bd354e51493.eu-west-1.compute.internal,i-0c014b64770a21fe7.eu-west-1.compute.internal)" cmd=agent sub=aggr
time="2024-10-15T09:05:13Z" level=info msg="Report: Jobs: ok/unknown/failed: 7/0/0" cmd=agent sub=aggr
time="2024-10-15T09:05:13Z" level=info msg="Report: SourceHost: ok/unknown/failed: 1/0/0" cmd=agent sub=aggr
time="2024-10-15T09:05:13Z" level=info msg="Report: DestHost: ok/unknown/failed: 5/0/0" cmd=agent sub=aggr
time="2024-10-15T09:06:14Z" level=info msg="Report: Jobs: ok/unknown/failed: 7/0/0" cmd=agent sub=aggr
time="2024-10-15T09:06:14Z" level=info msg="Report: SourceHost: ok/unknown/failed: 1/0/0" cmd=agent sub=aggr
time="2024-10-15T09:06:14Z" level=info msg="Report: DestHost: ok/unknown/failed: 5/0/0" cmd=agent sub=aggr
time="2024-10-15T09:07:15Z" level=info msg="Report: Jobs: ok/unknown/failed: 7/0/0" cmd=agent sub=aggr
time="2024-10-15T09:07:15Z" level=info msg="Report: SourceHost: ok/unknown/failed: 1/0/0" cmd=agent sub=aggr
time="2024-10-15T09:07:15Z" level=info msg="Report: DestHost: ok/unknown/failed: 5/0/0" cmd=agent sub=aggr
time="2024-10-15T09:08:16Z" level=info msg="Report: Jobs: ok/unknown/failed: 7/0/0" cmd=agent sub=aggr
time="2024-10-15T09:08:16Z" level=info msg="Report: SourceHost: ok/unknown/failed: 1/0/0" cmd=agent sub=aggr
time="2024-10-15T09:08:16Z" level=info msg="Report: DestHost: ok/unknown/failed: 5/0/0" cmd=agent sub=aggr
time="2024-10-15T09:09:16Z" level=info msg="Report: Jobs: ok/unknown/failed: 7/0/0" cmd=agent sub=aggr
time="2024-10-15T09:09:16Z" level=info msg="Report: SourceHost: ok/unknown/failed: 1/0/0" cmd=agent sub=aggr
time="2024-10-15T09:09:16Z" level=info msg="Report: DestHost: ok/unknown/failed: 5/0/0" cmd=agent sub=aggr
time="2024-10-15T09:10:17Z" level=info msg="Report: Jobs: ok/unknown/failed: 7/0/0" cmd=agent sub=aggr
time="2024-10-15T09:10:17Z" level=info msg="Report: SourceHost: ok/unknown/failed: 1/0/0" cmd=agent sub=aggr
time="2024-10-15T09:10:17Z" level=info msg="Report: DestHost: ok/unknown/failed: 5/0/0" cmd=agent sub=aggr
time="2024-10-15T09:11:18Z" level=info msg="Report: Jobs: ok/unknown/failed: 7/0/0" cmd=agent sub=aggr
time="2024-10-15T09:11:18Z" level=info msg="Report: SourceHost: ok/unknown/failed: 1/0/0" cmd=agent sub=aggr
time="2024-10-15T09:11:18Z" level=info msg="Report: DestHost: ok/unknown/failed: 5/0/0" cmd=agent sub=aggr
```
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Support tcp checks for ipv6 endpoints.
```
