### PR TITLE
Use filepath.Clean to get rid of gosec G304

### DIFF
--- a/pkg/agent/aggregation/aggregator.go
+++ b/pkg/agent/aggregation/aggregator.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -498,7 +499,7 @@ func (a *obsAggr) reportToFilesystem(report *reportData) {
 			a.log.Warnf("cannot rename %s to %s: %s", filename, old, err)
 		}
 	}
-	f, err := os.OpenFile(filename, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o640) //  #nosec G302 G304 -- no sensitive data
+	f, err := os.OpenFile(filepath.Clean(filename), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o640) //  #nosec G302 -- no sensitive data
 	if err != nil {
 		a.log.Warnf("cannot open %s: %s", filename, err)
 		return

--- a/pkg/agent/db/writer2.go
+++ b/pkg/agent/db/writer2.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -177,7 +178,7 @@ func readRecord(r io.Reader) (byte, []byte, error) {
 }
 
 func (w *obsWriter) loadStringIDMap(filename string) (*StringIDMap, error) {
-	f, err := os.OpenFile(filename, os.O_RDONLY, 0o640) //  #nosec G302 G304 -- no sensitive data
+	f, err := os.OpenFile(filepath.Clean(filename), os.O_RDONLY, 0o640) //  #nosec G302 -- no sensitive data
 	if err != nil {
 		if os.IsNotExist(err) {
 			return NewStringIDMap(), nil
@@ -238,7 +239,7 @@ func (w *obsWriter) getFile() (*writeFile, error) {
 		if err != nil {
 			return nil, err
 		}
-		f, err := os.OpenFile(filename, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o640) //  #nosec G302 G304 -- no sensitive data
+		f, err := os.OpenFile(filepath.Clean(filename), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o640) //  #nosec G302 -- no sensitive data
 		if err != nil {
 			return nil, err
 		}
@@ -418,7 +419,7 @@ func GetAnyRecordFiles(directory string, subdir bool) ([]string, error) {
 type ObservationVisitor func(obs *nwpd.Observation) error
 
 func IterateRecordFile(filename string, visitor ObservationVisitor) error {
-	f, err := os.OpenFile(filename, os.O_RDONLY, 0o640) //  #nosec G302 G304 -- no sensitive data
+	f, err := os.OpenFile(filepath.Clean(filename), os.O_RDONLY, 0o640) //  #nosec G302 -- no sensitive data
 	if err != nil {
 		return err
 	}

--- a/pkg/collect/command.go
+++ b/pkg/collect/command.go
@@ -174,13 +174,13 @@ func (cc *collectCommand) loadFrom(log logrus.FieldLogger, dir string, pod *core
 }
 
 func copyFile(srcFilename, destFilename string) (int64, error) {
-	input, err := os.Open(srcFilename) // #nosec G304
+	input, err := os.Open(filepath.Clean(srcFilename))
 	if err != nil {
 		return 0, err
 	}
 	defer input.Close()
 
-	output, err := os.Create(destFilename) // #nosec G304
+	output, err := os.Create(filepath.Clean(destFilename))
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/collect/command_run.go
+++ b/pkg/collect/command_run.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/gardener/network-problem-detector/pkg/common"
@@ -71,7 +72,7 @@ func createArchive(dir string, filenames []string, buf io.Writer) error {
 }
 
 func addFileToArchive(tw *tar.Writer, filename string) error {
-	file, err := os.Open(filename) // #nosec G304
+	file, err := os.Open(filepath.Clean(filename))
 	if err != nil {
 		return err
 	}

--- a/pkg/common/config/utils.go
+++ b/pkg/common/config/utils.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"path/filepath"
 
 	"sigs.k8s.io/yaml"
 )
@@ -17,7 +18,7 @@ import (
 var DisableShuffleForTesting = false
 
 func LoadAgentConfig(configFile string) (*AgentConfig, error) {
-	data, err := os.ReadFile(configFile) // #nosec G304
+	data, err := os.ReadFile(filepath.Clean(configFile))
 	if err != nil {
 		return nil, err
 	}
@@ -31,7 +32,7 @@ func LoadAgentConfig(configFile string) (*AgentConfig, error) {
 }
 
 func LoadClusterConfig(configFile string) (*ClusterConfig, error) {
-	data, err := os.ReadFile(configFile) // #nosec G304
+	data, err := os.ReadFile(filepath.Clean(configFile))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Minor improvement to get rid of gosec warning G304.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
