### PR TITLE
execute ipv4 and ipv6 pod and node checks for dual stack shoots

### DIFF
--- a/pkg/agent/runners/checktcpport.go
+++ b/pkg/agent/runners/checktcpport.go
@@ -49,11 +49,13 @@ func (a *checkTCPPortArgs) createRunner(_ *cobra.Command, _ []string) error {
 	case a.nodePort != 0:
 		allowEmpty = true
 		for _, n := range a.runnerArgs.clusterCfg.Nodes {
-			endpoints = append(endpoints, config.Endpoint{
-				Hostname: n.Hostname,
-				IP:       n.InternalIP,
-				Port:     a.nodePort,
-			})
+			for _, ip := range n.InternalIPs {
+				endpoints = append(endpoints, config.Endpoint{
+					Hostname: n.Hostname,
+					IP:       ip,
+					Port:     a.nodePort,
+				})
+			}
 		}
 	case a.podDS:
 		allowEmpty = true

--- a/pkg/agent/runners/parser_test.go
+++ b/pkg/agent/runners/parser_test.go
@@ -24,8 +24,8 @@ var _ = Describe("parser", func() {
 		clusterCfg1 = config.ClusterConfig{
 			NodeCount: 2,
 			Nodes: []config.Node{
-				{Hostname: "node1", InternalIP: "10.0.0.11"},
-				{Hostname: "node2", InternalIP: "10.0.0.12"},
+				{Hostname: "node1", InternalIPs: []string{"10.0.0.11"}},
+				{Hostname: "node2", InternalIPs: []string{"10.0.0.12"}},
 			},
 			PodEndpoints: []config.PodEndpoint{
 				{Nodename: "node1", Podname: "pod1", PodIP: "10.128.0.11", Port: 1234},
@@ -46,8 +46,8 @@ var _ = Describe("parser", func() {
 		clusterCfg2 = config.ClusterConfig{
 			NodeCount: 2,
 			Nodes: []config.Node{
-				{Hostname: "node3", InternalIP: "10.0.0.13"},
-				{Hostname: "node4", InternalIP: "10.0.0.14"},
+				{Hostname: "node3", InternalIPs: []string{"10.0.0.13"}},
+				{Hostname: "node4", InternalIPs: []string{"10.0.0.14"}},
 			},
 		}
 		endpoints1 = []config.Endpoint{

--- a/pkg/agent/runners/pinghost.go
+++ b/pkg/agent/runners/pinghost.go
@@ -31,7 +31,8 @@ func (a *pingHostArgs) createRunner(_ *cobra.Command, _ []string) error {
 			}
 			nodes = append(nodes, config.Node{
 				Hostname:    parts[0],
-				InternalIPs: []string{parts[1]}})
+				InternalIPs: []string{parts[1]},
+			})
 		}
 	} else {
 		nodes = a.runnerArgs.clusterCfg.Nodes

--- a/pkg/agent/runners/pinghost.go
+++ b/pkg/agent/runners/pinghost.go
@@ -30,9 +30,8 @@ func (a *pingHostArgs) createRunner(_ *cobra.Command, _ []string) error {
 				return fmt.Errorf("invalid job: %s: invalid host %s", strings.Join(a.runnerArgs.args, " "), host)
 			}
 			nodes = append(nodes, config.Node{
-				Hostname:   parts[0],
-				InternalIP: parts[1],
-			})
+				Hostname:    parts[0],
+				InternalIPs: []string{parts[1]}})
 		}
 	} else {
 		nodes = a.runnerArgs.clusterCfg.Nodes
@@ -77,32 +76,34 @@ type pingHost struct {
 var _ Runner = &pingHost{}
 
 func pingFunc(node config.Node) (string, error) {
-	pinger, err := ping.NewPinger(node.InternalIP)
-	if err != nil {
-		return "", err
-	}
-	pinger.SetPrivileged(true)
-	pinger.Count = 1
-	pinger.Timeout = 1 * time.Second
+	for _, ip := range node.InternalIPs {
+		pinger, err := ping.NewPinger(ip)
+		if err != nil {
+			return "", err
+		}
+		pinger.SetPrivileged(true)
+		pinger.Count = 1
+		pinger.Timeout = 1 * time.Second
 
-	result := atomic.String{}
-	pinger.OnRecv = func(pkt *ping.Packet) {
-		result.Store(fmt.Sprintf("%d bytes from %s: icmp_seq=%d time=%v\n",
-			pkt.Nbytes, pkt.IPAddr, pkt.Seq, pkt.Rtt))
-	}
+		result := atomic.String{}
+		pinger.OnRecv = func(pkt *ping.Packet) {
+			result.Store(fmt.Sprintf("%d bytes from %s: icmp_seq=%d time=%v\n",
+				pkt.Nbytes, pkt.IPAddr, pkt.Seq, pkt.Rtt))
+		}
 
-	pinger.OnDuplicateRecv = func(pkt *ping.Packet) {
-		result.Store(fmt.Sprintf("%d bytes from %s: icmp_seq=%d time=%v ttl=%v (DUP!)\n",
-			pkt.Nbytes, pkt.IPAddr, pkt.Seq, pkt.Rtt, pkt.Ttl))
-	}
+		pinger.OnDuplicateRecv = func(pkt *ping.Packet) {
+			result.Store(fmt.Sprintf("%d bytes from %s: icmp_seq=%d time=%v ttl=%v (DUP!)\n",
+				pkt.Nbytes, pkt.IPAddr, pkt.Seq, pkt.Rtt, pkt.Ttl))
+		}
 
-	err = pinger.Run()
-	if err != nil {
-		return "", err
+		err = pinger.Run()
+		if err != nil {
+			return "", err
+		}
+		stats := pinger.Statistics()
+		if stats.PacketsRecv == 1 {
+			return result.Load(), nil
+		}
 	}
-	stats := pinger.Statistics()
-	if stats.PacketsRecv == 1 {
-		return result.Load(), nil
-	}
-	return "", fmt.Errorf("ping lost after %d ms", pinger.Timeout.Milliseconds())
+	return "", fmt.Errorf("ping lost after %d ms", 1*time.Second.Milliseconds())
 }

--- a/pkg/common/config/endpoint.go
+++ b/pkg/common/config/endpoint.go
@@ -9,8 +9,8 @@ type WithDestHost interface {
 }
 
 type Node struct {
-	Hostname   string `json:"hostname"`
-	InternalIP string `json:"internalIP"`
+	Hostname    string   `json:"hostname"`
+	InternalIPs []string `json:"internalIPs"`
 }
 
 func (n Node) DestHost() string {

--- a/pkg/common/config/sample_test.go
+++ b/pkg/common/config/sample_test.go
@@ -27,14 +27,14 @@ var _ = Describe("sample", func() {
 	var podEndpoints2 []config.PodEndpoint
 	for i := 0; i < nodeCount; i++ {
 		hostname := fmt.Sprintf("host-%d", i)
-		nodes = append(nodes, config.Node{Hostname: hostname, InternalIP: fmt.Sprintf("10.0.0.%d", i+10)})
+		nodes = append(nodes, config.Node{Hostname: hostname, InternalIPs: []string{fmt.Sprintf("10.0.0.%d", i+10)}})
 		podEndpoints = append(podEndpoints, config.PodEndpoint{Nodename: hostname, Podname: fmt.Sprintf("pod%d", i), PodIP: fmt.Sprintf("10.128.0.%d", i+10), Port: 1234})
 		j := i
 		if shouldReplaceNode(i) {
 			j = i + nodeCount
 		}
 		hostname = fmt.Sprintf("host-%d", j)
-		nodes2 = append(nodes2, config.Node{Hostname: hostname, InternalIP: fmt.Sprintf("10.0.0.%d", j+10)})
+		nodes2 = append(nodes2, config.Node{Hostname: hostname, InternalIPs: []string{fmt.Sprintf("10.0.0.%d", j+10)}})
 		podEndpoints2 = append(podEndpoints2, config.PodEndpoint{Nodename: hostname, Podname: fmt.Sprintf("pod%d", j), PodIP: fmt.Sprintf("10.128.0.%d", j+10), Port: 1234})
 	}
 

--- a/pkg/deploy/clusterconfig.go
+++ b/pkg/deploy/clusterconfig.go
@@ -32,16 +32,16 @@ func BuildClusterConfig(
 	nodeNames := common.StringSet{}
 	for _, n := range nodes {
 		hostname := ""
-		ip := ""
+		ips := []string{}
 		for _, addr := range n.Status.Addresses {
 			switch addr.Type {
 			case "Hostname":
 				hostname = addr.Address
 			case "InternalIP":
-				ip = addr.Address
+				ips = append(ips, addr.Address)
 			}
 		}
-		if ip == "" {
+		if len(ips) == 0 {
 			log.Infof("ignore node %s without internalIP", n.Name)
 			continue
 		}
@@ -49,8 +49,8 @@ func BuildClusterConfig(
 			hostname = n.Name
 		}
 		clusterConfig.Nodes = append(clusterConfig.Nodes, config.Node{
-			Hostname:   hostname,
-			InternalIP: ip,
+			Hostname:    hostname,
+			InternalIPs: ips,
 		})
 		nodeNames.Add(hostname)
 	}

--- a/pkg/deploy/clusterconfig.go
+++ b/pkg/deploy/clusterconfig.go
@@ -59,12 +59,14 @@ func BuildClusterConfig(
 		if p.Status.Phase != corev1.PodRunning || !nodeNames.Contains(p.Spec.NodeName) {
 			continue
 		}
-		clusterConfig.PodEndpoints = append(clusterConfig.PodEndpoints, config.PodEndpoint{
-			Nodename: p.Spec.NodeName,
-			Podname:  p.Name,
-			PodIP:    p.Status.PodIP,
-			Port:     common.PodNetPodHTTPPort,
-		})
+		for _, podIP := range p.Status.PodIPs {
+			clusterConfig.PodEndpoints = append(clusterConfig.PodEndpoints, config.PodEndpoint{
+				Nodename: p.Spec.NodeName,
+				Podname:  p.Name,
+				PodIP:    podIP.IP,
+				Port:     common.PodNetPodHTTPPort,
+			})
+		}
 	}
 
 	sort.Slice(clusterConfig.Nodes, func(i, j int) bool {


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request adapts the pod and node to node checks to test both IP address families for dual-stack shoot clusters.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Node and pod checks are adapted to test both IP address families for dual-stack shoot clusters.
```
