### PR TITLE
Forbid container privilege escalations for the Network Problem Detector container components

### DIFF
--- a/pkg/deploy/agent.go
+++ b/pkg/deploy/agent.go
@@ -276,7 +276,8 @@ func (ac *AgentDeployConfig) buildDaemonSet(serviceAccountName string, hostNetwo
 							},
 						},
 						SecurityContext: &corev1.SecurityContext{
-							Capabilities: capabilities,
+							AllowPrivilegeEscalation: ptr.To(false),
+							Capabilities:             capabilities,
 						},
 						VolumeMounts: []corev1.VolumeMount{
 							{
@@ -420,8 +421,9 @@ func (ac *AgentDeployConfig) buildControllerDeployment() (*appsv1.Deployment, *r
 							},
 						},
 						SecurityContext: &corev1.SecurityContext{
-							RunAsUser:  ptr.To[int64](65534),
-							RunAsGroup: ptr.To[int64](65534),
+							AllowPrivilegeEscalation: ptr.To(false),
+							RunAsUser:                ptr.To[int64](65534),
+							RunAsGroup:               ptr.To[int64](65534),
 						},
 					}},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR sets `securityContext.allowPrivilegeEscalation` to false for every 'ETCD-Druid' component container, which does not have `securityContext.Privileged` set to `true` or one of `CAP_SYS_ADMIN/SYS_ADMIN` capabilities added.

**Which issue(s) this PR fixes**:
Part of gardener/gardener#11139

**Special notes for your reviewer**:
cc @AleksandarSavchev 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Component containers, which do not require privilege escalations, now forbid privilege escalation explicitly.
```
