### PR TITLE
fix(deploy): trim all newlines from defaultRepository

### DIFF
--- a/pkg/deploy/agent.go
+++ b/pkg/deploy/agent.go
@@ -89,7 +89,7 @@ func NetworkProblemDetectorAgent(config *AgentDeployConfig) ([]Object, error) {
 }
 
 func (ac *AgentDeployConfig) AddImageFlag(imageTag string, flags *pflag.FlagSet) {
-	defaultImage := defaultRepository + ":" + imageTag
+	defaultImage := strings.TrimRight(defaultRepository, "\n") + ":" + imageTag
 	flags.StringVar(&ac.Image, "image", strings.TrimSpace(defaultImage), "the nwpd container image to use.")
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the [pkg/deploy/DEFAULT_REPOSITORY](https://github.com/gardener/network-problem-detector/blob/main/pkg/deploy/DEFAULT_REPOSITORY) file contains a newline at the end.
This causes the following issue when not overriding the image using `--image`:

```
Warning  InspectFailed  14s (x3 over 26s)  kubelet            Failed to apply default image tag "europe-docker.pkg.dev/gardener-project/public/gardener/network-problem-detector\n:v0.25.0": couldn't parse image name "europe-docker.pkg.dev/gardener-project/public/gardener/network-problem-detector\n:v0.25.0": invalid reference format
Warning  Failed         14s (x3 over 26s)  kubelet            Error: InvalidImageName
```

**Special notes for your reviewer**:
I've decided to remove all trailing newlines programmatically instead of fixing the file, as many editors automatically add a trailing newline on save.