### PR TITLE
fix(controller): ensure `shootInfo` is nil if `Get` errored with `404`

### DIFF
--- a/pkg/controller/watch.go
+++ b/pkg/controller/watch.go
@@ -255,7 +255,7 @@ func (w *watch) Start(ctx context.Context) error {
 		}
 		cfg, err = deploy.BuildClusterConfig(w.log, nodes, pods, internalAPIServer, apiServer)
 		if err != nil {
-			w.log.Errorf("building cluster config failed: %w", err)
+			w.log.Errorf("building cluster config failed: %s", err)
 			continue
 		}
 		cfgBytes, err := yaml.Marshal(cfg)
@@ -285,7 +285,7 @@ func (w *watch) apiServerAddressChanged(shootInfo *corev1.ConfigMap, apiServer *
 	}
 	newAPIServer, err := deploy.GetAPIServerEndpointFromShootInfo(shootInfo)
 	if err != nil {
-		w.log.Errorf("failed to determine apiserver endpoint from shoot info: %w", err)
+		w.log.Errorf("failed to determine apiserver endpoint from shoot info: %s", err)
 		return true
 	}
 	return *newAPIServer != *apiServer

--- a/pkg/controller/watch.go
+++ b/pkg/controller/watch.go
@@ -231,6 +231,8 @@ func (w *watch) Start(ctx context.Context) error {
 				w.log.Errorf("loading configmap %s/%s failed: %s", common.NamespaceKubeSystem, common.NameGardenerShootInfo, err)
 				continue
 			}
+			// NOTE: client-go returns an empty object, even if the requested object does not exist.
+			shootInfo = nil
 		}
 		if err == nil {
 			apiServer, err = deploy.GetAPIServerEndpointFromShootInfo(shootInfo)


### PR DESCRIPTION
**What this PR does / why we need it**:
It fixes the following log line from being written on every reconcile:

```
level=error msg="failed to determine apiserver endpoint from shoot info: %!w(*errors.errorString=&{missing 'domain' key in configmap kube-system/shoot-info})" cmd=controller
```

This happens because `client-go` always returns an (empty) object, regardless if the requested object exists.
Thus we are now setting `shootInfo` explicitly to `nil` again, if the `GET` call returned with a `404`.

I've additionally fixed two log calls where `%w` instead of `%s` was used.