### PR TITLE
Reword step 4 of the adhoc stand-alone deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ Follow these steps to deploy NWPD to a Kubernetes cluster:
    *Note:* Run `./nwpdcli deploy agent --help` to see more options.
 
 
-4. Optional: In a second shell run the controller to update the configuration on changes of nodes and pod endpoints of the pod network daemon set with
+4. To enable automatic update of the configuration on changes of nodes and pod endpoints of the pod network daemon set, run the controller in a second shell with
 
    ```bash
    ./nwpdcli run-controller
    ```
 
-   Alternatively install the agent controller with
+   Alternatively, install the agent controller with
 
    ```bash
    ./nwpdcli deploy controller


### PR DESCRIPTION
**What this PR does / why we need it**:
Clearify that the controller is needed for automatic updates of the cluster config. 

**Which issue(s) this PR fixes**:
Fixes #98

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
NONE
```
