### PR TITLE
Fix/secondary nic filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ which is mounted as a volume in the pod. This `ConfigMap` is updated by the NWPD
 nodes and pods in the kube-system namespace. As soon as a kubelet discovers these changes, the agents see them as a file change.
 
 The results of the checks are stored locally on the node filesystem for later inspection with the `nwpdcli` command line tool.
-Additionally they are also exposed as metrics for scrapping by Prometheus.
+Additionally they are also exposed as metrics for scraping by Prometheus.
 By enabling the `K8s exporter`, the agents periodically patch the node conditions `ClusterNetworkProblem` and `HostNetworkProblem` in
 the status of the node resources. If checks are failing, a summarising event is created too.
 The `K8s exporter` is the only part of the agent which talks to the kube-apiserver.
@@ -40,7 +40,7 @@ To get started, the Network Problem Detector is deployed without integration wit
 
 *Side remark:*
 
-This is the fastest way to get started with NWPD. In a productive environment, you may prefer to scrap the check results
+This is the fastest way to get started with NWPD. In a productive environment, you may prefer to scrape the check results
 using [Prometheus](https://prometheus.io/) from metrics HTTP endpoints
 exposed by the agent pods. You may still follow this stand-alone installation, but
 you will need additional configuration on the Prometheus side which is not covered here.

--- a/pkg/controller/watch.go
+++ b/pkg/controller/watch.go
@@ -250,7 +250,11 @@ func (w *watch) Start(ctx context.Context) error {
 				nodeCIDRs = nil
 			}
 		}
-		w.log.Info("shoot info", "nodeCIDRs", nodeCIDRs, "apiserver", fmt.Sprintf("%s:%d", apiServer.Hostname, apiServer.Port))
+		apiserverStr := "<none>"
+		if apiServer != nil {
+			apiserverStr = fmt.Sprintf("%s:%d", apiServer.Hostname, apiServer.Port)
+		}
+		w.log.Info("shoot info", "nodeCIDRs", nodeCIDRs, "apiserver", apiserverStr)
 
 		cm, err := configmaps.Get(ctx, common.NameClusterConfigMap, metav1.GetOptions{})
 		if err != nil {

--- a/pkg/controller/watch.go
+++ b/pkg/controller/watch.go
@@ -246,8 +246,8 @@ func (w *watch) Start(ctx context.Context) error {
 		if err == nil {
 			nodeCIDRs, err = deploy.GetNodeNetworksFromShootInfo(shootInfo)
 			if err != nil {
-				w.log.Error(err, "fetching node networks from shoot info failed")
-				continue
+				w.log.Error(err, "failed to get node networks from shoot-info, proceeding without CIDR filtering")
+				nodeCIDRs = nil
 			}
 		}
 		w.log.Info("shoot info", "nodeCIDRs", nodeCIDRs, "apiserver", fmt.Sprintf("%s:%d", apiServer.Hostname, apiServer.Port))

--- a/pkg/controller/watch.go
+++ b/pkg/controller/watch.go
@@ -9,6 +9,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"time"
 
@@ -185,6 +186,7 @@ func (w *watch) Start(ctx context.Context) error {
 	var last time.Time
 	var shootInfo *corev1.ConfigMap
 	var apiServer *config.Endpoint
+	var nodeCIDRs []net.IPNet
 	for {
 		select {
 		case <-ctx.Done():
@@ -241,6 +243,14 @@ func (w *watch) Start(ctx context.Context) error {
 				continue
 			}
 		}
+		if err == nil {
+			nodeCIDRs, err = deploy.GetNodeNetworksFromShootInfo(shootInfo)
+			if err != nil {
+				w.log.Error(err, "fetching node networks from shoot info failed")
+				continue
+			}
+		}
+		w.log.Info("shoot info", "nodeCIDRs", nodeCIDRs, "apiserver", fmt.Sprintf("%s:%d", apiServer.Hostname, apiServer.Port))
 
 		cm, err := configmaps.Get(ctx, common.NameClusterConfigMap, metav1.GetOptions{})
 		if err != nil {
@@ -253,7 +263,7 @@ func (w *watch) Start(ctx context.Context) error {
 			w.log.Error(err, "unmarshal configmap failed", "configmap", fmt.Sprintf("%s/%s", common.NamespaceKubeSystem, common.NameClusterConfigMap))
 			continue
 		}
-		cfg, err = deploy.BuildClusterConfig(w.log, nodes, pods, internalAPIServer, apiServer)
+		cfg, err = deploy.BuildClusterConfig(w.log, nodes, pods, internalAPIServer, apiServer, nodeCIDRs)
 		if err != nil {
 			w.log.Error(err, "building cluster config failed")
 			continue

--- a/pkg/deploy/clusterconfig.go
+++ b/pkg/deploy/clusterconfig.go
@@ -50,6 +50,7 @@ func BuildClusterConfig(
 	agentPods []*corev1.Pod,
 	internalKubeAPIServer,
 	kubeAPIServer *config.Endpoint,
+	nodeCIDRs []net.IPNet,
 ) (*config.ClusterConfig, error) {
 	clusterConfig := &config.ClusterConfig{
 		InternalKubeAPIServer: internalKubeAPIServer,
@@ -74,10 +75,23 @@ func BuildClusterConfig(
 				if ip == nil {
 					continue
 				}
-				if ip.To4() != nil && arePodsIPv4 {
-					ips = append(ips, addr.Address)
-				} else if ip.To4() == nil && arePodsIPv6 {
-					ipsV6 = append(ipsV6, addr.Address)
+				if len(nodeCIDRs) == 0 { // can happen if not ShootInfo is available, e..g. with the --ignore-gardener-kube-api-server option
+					if ip.To4() != nil && arePodsIPv4 {
+						ips = append(ips, addr.Address)
+					} else if ip.To4() == nil && arePodsIPv6 {
+						ipsV6 = append(ipsV6, addr.Address)
+					}
+				} else {
+					for _, cidr := range nodeCIDRs {
+						if cidr.Contains(ip) {
+							if ip.To4() != nil && arePodsIPv4 {
+								ips = append(ips, addr.Address)
+							} else if ip.To4() == nil && arePodsIPv6 {
+								ipsV6 = append(ipsV6, addr.Address)
+							}
+							break
+						}
+					}
 				}
 			}
 		}
@@ -161,4 +175,43 @@ func GetAPIServerEndpointFromShootInfo(shootInfo *corev1.ConfigMap) (*config.End
 		IP:       ips[0].String(),
 		Port:     443,
 	}, nil
+}
+
+// Extract IPv4 and IPv6 node networks from the ShootInfo ConfigMap.
+func GetNodeNetworksFromShootInfo(shootInfo *corev1.ConfigMap) ([]net.IPNet, error) {
+	var networks []net.IPNet
+	nodeNetworks, ok := shootInfo.Data["nodeNetworks"]
+	if !ok {
+		return nil, fmt.Errorf("missing 'nodeNetworks' key")
+	}
+	if nodeNetworks == "" {
+		return nil, fmt.Errorf("empty 'nodeNetworks' value")
+	}
+	// Split the nodeNetworks value into individual CIDRs
+	cidrs := strings.Split(nodeNetworks, ",")
+	if len(cidrs) > 2 {
+		return nil, fmt.Errorf("invalid 'nodeNetworks' value (more than 2 CIDRs): %s", nodeNetworks)
+	}
+	var ipv4Found, ipv6Found bool
+	for i, cidr := range cidrs {
+		cidrs[i] = strings.TrimSpace(cidr)
+		_, parsedCIDR, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid 'nodeNetworks' value: %s", err)
+		}
+		if parsedCIDR.IP.To4() != nil {
+			if ipv4Found {
+				return nil, fmt.Errorf("invalid 'nodeNetworks' value (multiple IPv4 CIDRs): %s", nodeNetworks)
+			}
+			ipv4Found = true
+			networks = append(networks, *parsedCIDR)
+		} else {
+			if ipv6Found {
+				return nil, fmt.Errorf("invalid 'nodeNetworks' value (multiple IPv6 CIDRs): %s", nodeNetworks)
+			}
+			ipv6Found = true
+			networks = append(networks, *parsedCIDR)
+		}
+	}
+	return networks, nil
 }

--- a/pkg/deploy/clusterconfig.go
+++ b/pkg/deploy/clusterconfig.go
@@ -187,31 +187,13 @@ func GetNodeNetworksFromShootInfo(shootInfo *corev1.ConfigMap) ([]net.IPNet, err
 	if nodeNetworks == "" {
 		return nil, fmt.Errorf("empty 'nodeNetworks' value")
 	}
-	// Split the nodeNetworks value into individual CIDRs
-	cidrs := strings.Split(nodeNetworks, ",")
-	if len(cidrs) > 2 {
-		return nil, fmt.Errorf("invalid 'nodeNetworks' value (more than 2 CIDRs): %s", nodeNetworks)
-	}
-	var ipv4Found, ipv6Found bool
-	for i, cidr := range cidrs {
-		cidrs[i] = strings.TrimSpace(cidr)
+	for cidr := range strings.SplitSeq(nodeNetworks, ",") {
+		cidr = strings.TrimSpace(cidr)
 		_, parsedCIDR, err := net.ParseCIDR(cidr)
 		if err != nil {
 			return nil, fmt.Errorf("invalid 'nodeNetworks' value: %s", err)
 		}
-		if parsedCIDR.IP.To4() != nil {
-			if ipv4Found {
-				return nil, fmt.Errorf("invalid 'nodeNetworks' value (multiple IPv4 CIDRs): %s", nodeNetworks)
-			}
-			ipv4Found = true
-			networks = append(networks, *parsedCIDR)
-		} else {
-			if ipv6Found {
-				return nil, fmt.Errorf("invalid 'nodeNetworks' value (multiple IPv6 CIDRs): %s", nodeNetworks)
-			}
-			ipv6Found = true
-			networks = append(networks, *parsedCIDR)
-		}
+		networks = append(networks, *parsedCIDR)
 	}
 	return networks, nil
 }

--- a/pkg/deploy/clusterconfig_test.go
+++ b/pkg/deploy/clusterconfig_test.go
@@ -5,7 +5,7 @@
 package deploy_test
 
 import (
-	"slices"
+	"net"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -17,6 +17,13 @@ import (
 )
 
 var _ = Describe("BuildClusterConfig", func() {
+	var nodeCIDRs []net.IPNet
+	BeforeEach(func() {
+		_, v4, _ := net.ParseCIDR("192.168.1.0/24")
+		_, v6A, _ := net.ParseCIDR("2001:db8::/48")
+		_, v6B, _ := net.ParseCIDR("2001:db8:1::/48")
+		nodeCIDRs = []net.IPNet{*v4, *v6A, *v6B}
+	})
 	It("should build cluster config correctly", func() {
 		log := logr.Discard()
 		nodes := []*corev1.Node{
@@ -53,13 +60,12 @@ var _ = Describe("BuildClusterConfig", func() {
 			Port:     443,
 		}
 
-		clusterConfig, err := deploy.BuildClusterConfig(log, nodes, agentPods, internalKubeAPIServer, kubeAPIServer)
+		clusterConfig, err := deploy.BuildClusterConfig(log, nodes, agentPods, internalKubeAPIServer, kubeAPIServer, nodeCIDRs)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(clusterConfig).NotTo(BeNil())
 		Expect(clusterConfig.NodeCount).To(Equal(1))
 		Expect(clusterConfig.Nodes[0].Hostname).To(Equal("node1"))
-		Expect(len(clusterConfig.Nodes[0].InternalIPs)).To(Equal(1))
-		Expect(slices.Contains(clusterConfig.Nodes[0].InternalIPs, ("192.168.1.1"))).To(BeTrue())
+		Expect(clusterConfig.Nodes[0].InternalIPs).To(ConsistOf("192.168.1.1"))
 		Expect(clusterConfig.PodEndpoints[0].Nodename).To(Equal("node1"))
 		Expect(clusterConfig.PodEndpoints[0].PodIP).To(Equal("10.0.0.1"))
 	})
@@ -100,13 +106,12 @@ var _ = Describe("BuildClusterConfig", func() {
 			Port:     443,
 		}
 
-		clusterConfig, err := deploy.BuildClusterConfig(log, nodes, agentPods, internalKubeAPIServer, kubeAPIServer)
+		clusterConfig, err := deploy.BuildClusterConfig(log, nodes, agentPods, internalKubeAPIServer, kubeAPIServer, nodeCIDRs)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(clusterConfig).NotTo(BeNil())
 		Expect(clusterConfig.NodeCount).To(Equal(1))
 		Expect(clusterConfig.Nodes[0].Hostname).To(Equal("node1"))
-		Expect(len(clusterConfig.Nodes[0].InternalIPsV6)).To(Equal(1))
-		Expect(slices.Contains(clusterConfig.Nodes[0].InternalIPsV6, ("2001:db8::1"))).To(BeTrue())
+		Expect(clusterConfig.Nodes[0].InternalIPsV6).To(ConsistOf("2001:db8::1"))
 		Expect(clusterConfig.PodEndpointsV6[0].Nodename).To(Equal("node1"))
 		Expect(clusterConfig.PodEndpointsV6[0].PodIP).To(Equal("2001:db8::2"))
 	})
@@ -148,13 +153,12 @@ var _ = Describe("BuildClusterConfig", func() {
 			Port:     443,
 		}
 
-		clusterConfig, err := deploy.BuildClusterConfig(log, nodes, agentPods, internalKubeAPIServer, kubeAPIServer)
+		clusterConfig, err := deploy.BuildClusterConfig(log, nodes, agentPods, internalKubeAPIServer, kubeAPIServer, nodeCIDRs)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(clusterConfig).NotTo(BeNil())
 		Expect(clusterConfig.NodeCount).To(Equal(1))
 		Expect(clusterConfig.Nodes[0].Hostname).To(Equal("node1"))
-		Expect(len(clusterConfig.Nodes[0].InternalIPs)).To(Equal(1))
-		Expect(slices.Contains(clusterConfig.Nodes[0].InternalIPs, ("192.168.1.1"))).To(BeTrue())
+		Expect(clusterConfig.Nodes[0].InternalIPs).To(ConsistOf("192.168.1.1"))
 		Expect(clusterConfig.PodEndpoints[0].Nodename).To(Equal("node1"))
 		Expect(clusterConfig.PodEndpoints[0].PodIP).To(Equal("10.0.0.1"))
 	})
@@ -209,13 +213,12 @@ var _ = Describe("BuildClusterConfig", func() {
 			Port:     443,
 		}
 
-		clusterConfig, err := deploy.BuildClusterConfig(log, nodes, agentPods, internalKubeAPIServer, kubeAPIServer)
+		clusterConfig, err := deploy.BuildClusterConfig(log, nodes, agentPods, internalKubeAPIServer, kubeAPIServer, nodeCIDRs)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(clusterConfig).NotTo(BeNil())
 		Expect(clusterConfig.NodeCount).To(Equal(1))
 		Expect(clusterConfig.Nodes[0].Hostname).To(Equal("node1"))
-		Expect(len(clusterConfig.Nodes[0].InternalIPs)).To(Equal(1))
-		Expect(slices.Contains(clusterConfig.Nodes[0].InternalIPs, ("192.168.1.1"))).To(BeTrue())
+		Expect(clusterConfig.Nodes[0].InternalIPs).To(ConsistOf("192.168.1.1"))
 		Expect(clusterConfig.PodEndpoints[0].Nodename).To(Equal("node1"))
 		Expect(clusterConfig.PodEndpoints[0].PodIP).To(Equal("10.0.0.1"))
 	})
@@ -258,15 +261,13 @@ var _ = Describe("BuildClusterConfig", func() {
 			Port:     443,
 		}
 
-		clusterConfig, err := deploy.BuildClusterConfig(log, nodes, agentPods, internalKubeAPIServer, kubeAPIServer)
+		clusterConfig, err := deploy.BuildClusterConfig(log, nodes, agentPods, internalKubeAPIServer, kubeAPIServer, nodeCIDRs)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(clusterConfig).NotTo(BeNil())
 		Expect(clusterConfig.NodeCount).To(Equal(1))
 		Expect(clusterConfig.Nodes[0].Hostname).To(Equal("node1"))
-		Expect(len(clusterConfig.Nodes[0].InternalIPs)).To(Equal(1))
-		Expect(len(clusterConfig.Nodes[0].InternalIPsV6)).To(Equal(1))
-		Expect(slices.Contains(clusterConfig.Nodes[0].InternalIPs, ("192.168.1.1"))).To(BeTrue())
-		Expect(slices.Contains(clusterConfig.Nodes[0].InternalIPsV6, ("2001:db8::1"))).To(BeTrue())
+		Expect(clusterConfig.Nodes[0].InternalIPs).To(ConsistOf("192.168.1.1"))
+		Expect(clusterConfig.Nodes[0].InternalIPsV6).To(ConsistOf("2001:db8::1"))
 		Expect(clusterConfig.PodEndpoints[0].Nodename).To(Equal("node1"))
 		Expect(clusterConfig.PodEndpoints[0].PodIP).To(Equal("10.0.0.1"))
 	})
@@ -318,15 +319,14 @@ var _ = Describe("BuildClusterConfig", func() {
 			Port:     443,
 		}
 
-		clusterConfig, err := deploy.BuildClusterConfig(log, nodes, agentPods, internalKubeAPIServer, kubeAPIServer)
+		clusterConfig, err := deploy.BuildClusterConfig(log, nodes, agentPods, internalKubeAPIServer, kubeAPIServer, nodeCIDRs)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(clusterConfig).NotTo(BeNil())
 		Expect(clusterConfig.NodeCount).To(Equal(1))
 		Expect(clusterConfig.Nodes[0].Hostname).To(Equal("node1"))
-		Expect(len(clusterConfig.Nodes[0].InternalIPs)).To(Equal(1))
-		Expect(slices.Contains(clusterConfig.Nodes[0].InternalIPs, ("192.168.1.1"))).To(BeTrue())
+		Expect(clusterConfig.Nodes[0].InternalIPs).To(ConsistOf("192.168.1.1"))
 		// Should only have one pod endpoint (the one with valid IP)
-		Expect(len(clusterConfig.PodEndpoints)).To(Equal(1))
+		Expect(clusterConfig.PodEndpoints).To(HaveLen(1))
 		Expect(clusterConfig.PodEndpoints[0].Nodename).To(Equal("node1"))
 		Expect(clusterConfig.PodEndpoints[0].PodIP).To(Equal("10.0.0.1"))
 	})
@@ -378,15 +378,231 @@ var _ = Describe("BuildClusterConfig", func() {
 			Port:     443,
 		}
 
-		clusterConfig, err := deploy.BuildClusterConfig(log, nodes, agentPods, internalKubeAPIServer, kubeAPIServer)
+		clusterConfig, err := deploy.BuildClusterConfig(log, nodes, agentPods, internalKubeAPIServer, kubeAPIServer, nodeCIDRs)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(clusterConfig).NotTo(BeNil())
 		Expect(clusterConfig.NodeCount).To(Equal(1))
 		Expect(clusterConfig.Nodes[0].Hostname).To(Equal("node1"))
-		Expect(len(clusterConfig.Nodes[0].InternalIPs)).To(Equal(1))
-		Expect(slices.Contains(clusterConfig.Nodes[0].InternalIPs, ("192.168.1.1"))).To(BeTrue())
+		Expect(clusterConfig.Nodes[0].InternalIPs).To(ConsistOf("192.168.1.1"))
 		// Should have no pod endpoints since all pods have invalid IPs
-		Expect(len(clusterConfig.PodEndpoints)).To(Equal(0))
-		Expect(len(clusterConfig.PodEndpointsV6)).To(Equal(0))
+		Expect(clusterConfig.PodEndpoints).To(BeEmpty())
+		Expect(clusterConfig.PodEndpointsV6).To(BeEmpty())
+	})
+
+	It("should only include IPs from the node CIDRs in the cluster config if a node has multiple IPs", func() {
+		log := logr.Discard()
+		nodes := []*corev1.Node{
+			{
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{
+						{Type: corev1.NodeInternalIP, Address: "192.168.1.1"},
+						{Type: corev1.NodeInternalIP, Address: "10.180.1.1"},
+						{Type: corev1.NodeInternalIP, Address: "2001:db8::1"},
+						{Type: corev1.NodeInternalIP, Address: "2a05:d018:a7c:d500::1"},
+						{Type: corev1.NodeHostName, Address: "node1"},
+					},
+				},
+			},
+			{
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{
+						{Type: corev1.NodeInternalIP, Address: "10.180.1.2"},
+						{Type: corev1.NodeInternalIP, Address: "192.168.1.2"},
+						{Type: corev1.NodeInternalIP, Address: "2a05:d018:a7c:d500::2"},
+						{Type: corev1.NodeInternalIP, Address: "2001:db8:1::2"},
+						{Type: corev1.NodeHostName, Address: "node2"},
+					},
+				},
+			},
+		}
+		agentPods := []*corev1.Pod{
+			{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					PodIPs: []corev1.PodIP{
+						{IP: "10.0.0.1"},
+						{IP: "2001:db8::1"},
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "node1",
+				},
+			},
+			{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					PodIPs: []corev1.PodIP{
+						{IP: "10.0.0.2"},
+						{IP: "2001:db8::2"},
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "node2",
+				},
+			},
+		}
+		internalKubeAPIServer := &config.Endpoint{
+			Hostname: "internal-api-server",
+			IP:       "192.168.1.2",
+			Port:     443,
+		}
+		kubeAPIServer := &config.Endpoint{
+			Hostname: "api-server",
+			IP:       "192.168.1.3",
+			Port:     443,
+		}
+		clusterConfig, err := deploy.BuildClusterConfig(log, nodes, agentPods, internalKubeAPIServer, kubeAPIServer, nodeCIDRs)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(clusterConfig).NotTo(BeNil())
+		// should only include the IPs from the node CIDRs in the cluster config (IPv4 and IPv6)
+		Expect(clusterConfig.Nodes[0].InternalIPs).To(ConsistOf("192.168.1.1"))
+		Expect(clusterConfig.Nodes[0].InternalIPsV6).To(ConsistOf("2001:db8::1"))
+		Expect(clusterConfig.Nodes[1].InternalIPs).To(ConsistOf("192.168.1.2"))
+		Expect(clusterConfig.Nodes[1].InternalIPsV6).To(ConsistOf("2001:db8:1::2"))
+	})
+	It("should include all IPs when no node CIDRs are provided", func() {
+		log := logr.Discard()
+		nodes := []*corev1.Node{
+			{
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{
+						{Type: corev1.NodeInternalIP, Address: "192.168.1.1"},
+						{Type: corev1.NodeInternalIP, Address: "10.180.1.1"},
+						{Type: corev1.NodeHostName, Address: "node1"},
+					},
+				},
+			},
+		}
+		agentPods := []*corev1.Pod{
+			{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					PodIPs: []corev1.PodIP{
+						{IP: "10.0.0.1"},
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "node1",
+				},
+			},
+		}
+
+		clusterConfig, err := deploy.BuildClusterConfig(log, nodes, agentPods, &config.Endpoint{
+			Hostname: "internal-api-server",
+			IP:       "192.168.1.2",
+			Port:     443,
+		}, &config.Endpoint{
+			Hostname: "api-server",
+			IP:       "192.168.1.3",
+			Port:     443,
+		}, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(clusterConfig.NodeCount).To(Equal(1))
+		Expect(clusterConfig.Nodes[0].InternalIPs).To(ConsistOf("192.168.1.1", "10.180.1.1"))
+	})
+})
+
+var _ = Describe("GetNodeNetworksFromShootInfo", func() {
+	Context("correctly configured shoot info", func() {
+		It("should return the IPv4 network for an IPv4-only cluster", func() {
+			shootInfo := &corev1.ConfigMap{
+				Data: map[string]string{
+					"nodeNetworks": "10.180.0.0/16",
+				},
+			}
+			nodeCIDRs, err := deploy.GetNodeNetworksFromShootInfo(shootInfo)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nodeCIDRs).To(HaveLen(1))
+			Expect(nodeCIDRs[0].String()).To(Equal("10.180.0.0/16"))
+		})
+		It("should return the IPv6 network for an IPv6-only cluster", func() {
+			shootInfo := &corev1.ConfigMap{
+				Data: map[string]string{
+					"nodeNetworks": "2a05:d018:a7c:d500::/56",
+				},
+			}
+			nodeCIDRs, err := deploy.GetNodeNetworksFromShootInfo(shootInfo)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nodeCIDRs).To(HaveLen(1))
+			Expect(nodeCIDRs[0].String()).To(Equal("2a05:d018:a7c:d500::/56"))
+		})
+		It("should return both IPv4 and IPv6 networks for a dual-stack cluster", func() {
+			shootInfo := &corev1.ConfigMap{
+				Data: map[string]string{
+					"nodeNetworks": "10.180.0.0/16,2a05:d018:a7c:d500::/56",
+				},
+			}
+			nodeCIDRs, err := deploy.GetNodeNetworksFromShootInfo(shootInfo)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nodeCIDRs).To(HaveLen(2))
+			Expect(nodeCIDRs[0].String()).To(Equal("10.180.0.0/16"))
+			Expect(nodeCIDRs[1].String()).To(Equal("2a05:d018:a7c:d500::/56"))
+		})
+	})
+	Context("misconfigured shoot info", func() {
+		It("should return an error for a missing nodeNetworks key", func() {
+			shootInfo := &corev1.ConfigMap{
+				Data: map[string]string{},
+			}
+			nodeCIDRs, err := deploy.GetNodeNetworksFromShootInfo(shootInfo)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring("missing 'nodeNetworks' key")))
+			Expect(nodeCIDRs).To(BeNil())
+		})
+		It("should return an error for an empty nodeNetworks value", func() {
+			shootInfo := &corev1.ConfigMap{
+				Data: map[string]string{
+					"nodeNetworks": "",
+				},
+			}
+			nodeCIDRs, err := deploy.GetNodeNetworksFromShootInfo(shootInfo)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring("empty 'nodeNetworks' value")))
+			Expect(nodeCIDRs).To(BeNil())
+		})
+		It("should return an error for a nodeNetworks value with more than two CIDRs", func() {
+			shootInfo := &corev1.ConfigMap{
+				Data: map[string]string{
+					"nodeNetworks": "10.180.0.0/16,2a05:d018:a7c:d500::/56,192.168.0.0/16",
+				},
+			}
+			nodeCIDRs, err := deploy.GetNodeNetworksFromShootInfo(shootInfo)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring("invalid 'nodeNetworks' value")))
+			Expect(nodeCIDRs).To(BeNil())
+		})
+		It("should return an error for an invalid nodeNetworks value", func() {
+			shootInfo := &corev1.ConfigMap{
+				Data: map[string]string{
+					"nodeNetworks": "invalid-network",
+				},
+			}
+			nodeCIDRs, err := deploy.GetNodeNetworksFromShootInfo(shootInfo)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring("invalid 'nodeNetworks' value")))
+			Expect(nodeCIDRs).To(BeNil())
+		})
+		It("should return an error for a nodeNetworks value with two IPv4 CIDRs", func() {
+			shootInfo := &corev1.ConfigMap{
+				Data: map[string]string{
+					"nodeNetworks": "10.180.0.0/16,192.168.0.0/16",
+				},
+			}
+			nodeCIDRs, err := deploy.GetNodeNetworksFromShootInfo(shootInfo)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring("invalid 'nodeNetworks' value")))
+			Expect(nodeCIDRs).To(BeNil())
+		})
+		It("should return an error for a nodeNetworks value with two IPv6 CIDRs", func() {
+			shootInfo := &corev1.ConfigMap{
+				Data: map[string]string{
+					"nodeNetworks": "2a05:d018:a7c:d500::/56,2a05:d018:a7c:d501::/56",
+				},
+			}
+			nodeCIDRs, err := deploy.GetNodeNetworksFromShootInfo(shootInfo)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring("invalid 'nodeNetworks' value")))
+			Expect(nodeCIDRs).To(BeNil())
+		})
 	})
 })

--- a/pkg/deploy/clusterconfig_test.go
+++ b/pkg/deploy/clusterconfig_test.go
@@ -560,16 +560,15 @@ var _ = Describe("GetNodeNetworksFromShootInfo", func() {
 			Expect(err).To(MatchError(ContainSubstring("empty 'nodeNetworks' value")))
 			Expect(nodeCIDRs).To(BeNil())
 		})
-		It("should return an error for a nodeNetworks value with more than two CIDRs", func() {
+		It("should return all CIDRs for a nodeNetworks value with more than two CIDRs", func() {
 			shootInfo := &corev1.ConfigMap{
 				Data: map[string]string{
-					"nodeNetworks": "10.180.0.0/16,2a05:d018:a7c:d500::/56,192.168.0.0/16",
+					"nodeNetworks": "10.180.0.0/16,2a05:d018:a7c:d500::/56,2a05:d018:a7c:d501::/56",
 				},
 			}
 			nodeCIDRs, err := deploy.GetNodeNetworksFromShootInfo(shootInfo)
-			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(ContainSubstring("invalid 'nodeNetworks' value")))
-			Expect(nodeCIDRs).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nodeCIDRs).To(HaveLen(3))
 		})
 		It("should return an error for an invalid nodeNetworks value", func() {
 			shootInfo := &corev1.ConfigMap{
@@ -582,27 +581,25 @@ var _ = Describe("GetNodeNetworksFromShootInfo", func() {
 			Expect(err).To(MatchError(ContainSubstring("invalid 'nodeNetworks' value")))
 			Expect(nodeCIDRs).To(BeNil())
 		})
-		It("should return an error for a nodeNetworks value with two IPv4 CIDRs", func() {
+		It("should return all CIDRs for a nodeNetworks value with two IPv4 CIDRs", func() {
 			shootInfo := &corev1.ConfigMap{
 				Data: map[string]string{
 					"nodeNetworks": "10.180.0.0/16,192.168.0.0/16",
 				},
 			}
 			nodeCIDRs, err := deploy.GetNodeNetworksFromShootInfo(shootInfo)
-			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(ContainSubstring("invalid 'nodeNetworks' value")))
-			Expect(nodeCIDRs).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nodeCIDRs).To(HaveLen(2))
 		})
-		It("should return an error for a nodeNetworks value with two IPv6 CIDRs", func() {
+		It("should return all CIDRs for a nodeNetworks value with two IPv6 CIDRs", func() {
 			shootInfo := &corev1.ConfigMap{
 				Data: map[string]string{
 					"nodeNetworks": "2a05:d018:a7c:d500::/56,2a05:d018:a7c:d501::/56",
 				},
 			}
 			nodeCIDRs, err := deploy.GetNodeNetworksFromShootInfo(shootInfo)
-			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(ContainSubstring("invalid 'nodeNetworks' value")))
-			Expect(nodeCIDRs).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nodeCIDRs).To(HaveLen(2))
 		})
 	})
 })

--- a/pkg/deploy/command.go
+++ b/pkg/deploy/command.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -274,12 +275,17 @@ func (dc *deployCommand) buildClusterConfigMap(log logr.Logger) (*corev1.ConfigM
 		Port:     int(svc.Spec.Ports[0].Port),
 	}
 	var apiServer *config.Endpoint
+	var nodeCIDRs []net.IPNet
 	if !dc.agentDeployConfig.IgnoreAPIServerEndpoint {
 		shootInfo, err := dc.Clientset.CoreV1().ConfigMaps(common.NamespaceKubeSystem).Get(ctx, common.NameGardenerShootInfo, metav1.GetOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("error getting configmap %s/%s: if this is no Gardener shoot cluster, please add option '--ignore-gardener-kube-api-server' to deploy command", common.NamespaceKubeSystem, common.NameGardenerShootInfo)
 		}
 		apiServer, err = GetAPIServerEndpointFromShootInfo(shootInfo)
+		if err != nil {
+			return nil, err
+		}
+		nodeCIDRs, err = GetNodeNetworksFromShootInfo(shootInfo)
 		if err != nil {
 			return nil, err
 		}
@@ -293,7 +299,7 @@ func (dc *deployCommand) buildClusterConfigMap(log logr.Logger) (*corev1.ConfigM
 		return nil, err
 	}
 
-	clusterConfig, err := BuildClusterConfig(log, nodes, agentPods, internalAPIServer, apiServer)
+	clusterConfig, err := BuildClusterConfig(log, nodes, agentPods, internalAPIServer, apiServer, nodeCIDRs)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:

On nodes with a secondary NIC, such as an
additional ENI in a different subnet, agents would probe the secondary
IP on the nwpd port. If that port isn't reachable through the secondary
NIC's security group / firewall rules, the probes fail and nwpd reports
false-positive TCP connectivity failures even though the node itself is
healthy.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Restrict network problem detector checks for nodes to node subnet
```
