### PR TITLE
chore: add renovate with automerge

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,7 +11,7 @@
   "packageRules": [
     {
       "matchDatasources": ["docker", "go-version"],
-      "matchPackagePatterns": ["golang"],
+      "matchPackageNames": ["golang"],
       "automerge": true
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "dependencyDashboard": true,
+  "extends": [
+    "config:recommended",
+    "github>gardener/ci-infra//config/renovate/automerge-with-tide.json5"
+  ],
+  "labels": ["kind/enhancement"],
+  "postUpdateOptions": ["gomodTidy"],
+  "separateMinorPatch": true,
+  "packageRules": [
+    {
+      "matchDatasources": ["docker", "go-version"],
+      "matchPackagePatterns": ["golang"],
+      "automerge": true
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchPackagePatterns": [
+        "^actions/checkout$",
+        "^actions/setup-go$",
+      ],
+      "automerge": true
+    },
+    {
+      // Ignore paths which most likely create false positives.
+      "matchFileNames": [
+        "chart/**",
+        "cmd/**",
+        "pkg/**",
+        "test/**",
+      ],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
- Enable auto-merging of dependencies using renvate
- Will remove dependabot in a separate PR once renovate is onboarded

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
