### PR TITLE
fix: add message format in Eventf call

### DIFF
--- a/pkg/agent/aggregation/condition/manager.go
+++ b/pkg/agent/aggregation/condition/manager.go
@@ -180,7 +180,7 @@ func (c *conditionManager) sync() {
 		c.log.Info("SetConditions was successful")
 		for i, condition := range conditions {
 			if condition.Status == corev1.ConditionTrue {
-				c.client.Eventf(corev1.EventTypeWarning, sources[i], condition.Reason, condition.Message)
+				c.client.Eventf(corev1.EventTypeWarning, sources[i], condition.Reason, "%s", condition.Message)
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
- `Eventf` requires a format string for sprintf which we don't provide currently
- This fails `go vet` in go 1.26 with the following message:

```
pkg/agent/aggregation/condition/manager.go:183:76: non-constant format string in call to (github.com/gardener/network-problem-detector/pkg/agent/aggregation/problemclient.Client).Eventf
```

**Which issue(s) this PR fixes**:
Unblocks https://github.com/gardener/network-problem-detector/pull/169

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
